### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix client-side HMAC security theater in rate limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The `templateImport.ts` module was reading user-provided files directly into memory using `FileReader.readAsText()` without any size limitations. Maliciously large JSON payloads can exhaust browser memory and freeze or crash the client application during import.
 **Learning:** Browser APIs like `FileReader` load entire file contents into RAM. Relying on implicit browser limits is insufficient, especially for large JSON formats which further multiply memory footprint.
 **Prevention:** Always enforce strict file size limits (e.g., 5MB for JSON templates) by checking `file.size` before initiating any file reading operations.
+
+## 2025-02-21 - [HMAC Security Theater in LocalStorage]
+**Vulnerability:** The client-side rate limiter generated an HMAC key to sign its state, but stored both the key and the state in plaintext `localStorage`. This provided zero real security, as an attacker with access to modify the state could also read the key to forge a valid signature.
+**Learning:** Storing cryptographic keys (like an HMAC key) in `localStorage` to sign or protect data that is also stored in `localStorage` is an anti-pattern (security theater) and provides no meaningful tamper resistance.
+**Prevention:** Avoid adding complex cryptographic mechanisms that provide no actual security benefit. When client-side security measures are just deterrents, keep them simple and acknowledge their limitations rather than creating a false sense of security with easily bypassed cryptography.

--- a/src/features/ledger/SchemaBuilder.tsx
+++ b/src/features/ledger/SchemaBuilder.tsx
@@ -30,6 +30,7 @@ export const SchemaBuilder: React.FC<SchemaBuilderProps> = ({ projectId, onClose
     const { schemas } = useLedgerStore();
     const {
         draftName,
+        setDraftName,
         draftFields,
         error,
         isLoading,

--- a/src/lib/rateLimiter.test.ts
+++ b/src/lib/rateLimiter.test.ts
@@ -52,7 +52,6 @@ describe('Rate Limiter', () => {
             expect(state.account).toBe('test-account');
             expect(state.attempts).toBe(1);
             expect(state.lockedUntil).toBeNull();
-            expect(state.signature).toBeDefined();
         });
 
         it('increments attempts on subsequent failures', async () => {
@@ -102,19 +101,6 @@ describe('Rate Limiter', () => {
             await recordFailedAttempt('account-1');
             
             const state = await getRateLimitState('account-2');
-            expect(state).toBeNull();
-        });
-
-        it('returns null if signature is missing (tampered)', async () => {
-            await recordFailedAttempt('test-account');
-            
-            // Tamper with state
-            const stored = localStorage.getItem('ledgy-auth-rate-limit');
-            const parsed = JSON.parse(stored!);
-            parsed.signature = '';
-            localStorage.setItem('ledgy-auth-rate-limit', JSON.stringify(parsed));
-            
-            const state = await getRateLimitState('test-account');
             expect(state).toBeNull();
         });
     });
@@ -322,46 +308,6 @@ describe('Rate Limiter', () => {
             
             const state = await getRateLimitState('test-account');
             expect(state?.attempts).toBe(1); // New sequence
-        });
-    });
-
-    describe('Security Fix: Dynamic HMAC Key', () => {
-        it('generates a unique HMAC key if none exists', async () => {
-            const HMAC_KEY_STORAGE_KEY = 'ledgy-rate-limit-hmac-key';
-
-            // Should be empty initially (beforeEach clears localStorage)
-            expect(localStorage.getItem(HMAC_KEY_STORAGE_KEY)).toBeNull();
-
-            // Action that triggers key generation
-            await recordFailedAttempt('test-account');
-
-            const key = localStorage.getItem(HMAC_KEY_STORAGE_KEY);
-            expect(key).not.toBeNull();
-            expect(key?.length).toBeGreaterThan(32); // Base64 encoded 32 bytes
-        });
-
-        it('persists the same HMAC key across attempts', async () => {
-            const HMAC_KEY_STORAGE_KEY = 'ledgy-rate-limit-hmac-key';
-
-            await recordFailedAttempt('test-account');
-            const key1 = localStorage.getItem(HMAC_KEY_STORAGE_KEY);
-
-            await recordFailedAttempt('test-account');
-            const key2 = localStorage.getItem(HMAC_KEY_STORAGE_KEY);
-
-            expect(key1).toBe(key2);
-        });
-
-        it('rejects state signed with a different key', async () => {
-            // 1. Create valid state
-            await recordFailedAttempt('test-account');
-
-            // 2. Change the HMAC key in storage
-            localStorage.setItem('ledgy-rate-limit-hmac-key', 'different-key-that-is-valid-base64-32bytes-long-long');
-
-            // 3. getRateLimitState should now return null because signature verification fails
-            const state = await getRateLimitState('test-account');
-            expect(state).toBeNull();
         });
     });
 });

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -2,7 +2,6 @@
  * Rate Limiter for Authentication Attempts
  * 
  * Implements exponential backoff and lockout after max failed attempts.
- * Uses HMAC signature to prevent tampering with localStorage state.
  * 
  * Security Note: This is CLIENT-SIDE rate limiting only.
  * It's a deterrent, not true security. Server-side rate limiting
@@ -16,67 +15,12 @@ const BASE_DELAY_MS = 1000; // 1 second
 const MAX_DELAY_MS = 30000; // 30 seconds cap
 const GRACE_PERIOD_MS = 5000; // 5 seconds for clock skew
 const STORAGE_KEY = 'ledgy-auth-rate-limit';
-const HMAC_KEY_STORAGE_KEY = 'ledgy-rate-limit-hmac-key';
 
 export interface RateLimitState {
     account: string;
     attempts: number;
     lastAttempt: number;
     lockedUntil: number | null;
-    signature: string;
-}
-
-/**
- * Get or generate the HMAC key for signing rate limit state.
- * The key is stored in localStorage to persist across sessions,
- * but is unique per client installation.
- */
-function getOrGenerateHMACKey(): string {
-    let key = localStorage.getItem(HMAC_KEY_STORAGE_KEY);
-    if (!key) {
-        // Generate a random 256-bit key (32 bytes)
-        const bytes = crypto.getRandomValues(new Uint8Array(32));
-        key = btoa(String.fromCharCode(...bytes));
-        localStorage.setItem(HMAC_KEY_STORAGE_KEY, key);
-    }
-    return key;
-}
-
-// Cache TextEncoder and CryptoKey at module level to avoid redundant
-// instantiation and computationally expensive WebCrypto API overhead
-// on every signature generation.
-const encoder = new TextEncoder();
-let hmacCryptoKey: CryptoKey | null = null;
-/**
- * Generate HMAC signature for state
- */
-async function generateSignature(state: Omit<RateLimitState, 'signature'>): Promise<string> {
-    const data = encoder.encode(JSON.stringify(state));
-
-    const hmacKey = getOrGenerateHMACKey();
-    const keyData = new Uint8Array(atob(hmacKey).split('').map(c => c.charCodeAt(0)));
-    
-    if (!hmacCryptoKey) {
-        hmacCryptoKey = await crypto.subtle.importKey(
-            'raw',
-            keyData,
-            { name: 'HMAC', hash: 'SHA-256' },
-            false,
-            ['sign']
-        );
-    }
-    
-    const signature = await crypto.subtle.sign('HMAC', hmacCryptoKey, data);
-    return btoa(String.fromCharCode(...new Uint8Array(signature)));
-}
-
-/**
- * Verify HMAC signature for state
- */
-async function verifySignature(state: RateLimitState): Promise<boolean> {
-    const { signature, ...unsignedState } = state;
-    const expectedSignature = await generateSignature(unsignedState);
-    return signature === expectedSignature;
 }
 
 /**
@@ -103,13 +47,6 @@ export async function getRateLimitState(account: string): Promise<RateLimitState
         
         // Verify account matches
         if (state.account !== account) return null;
-        
-        // Verify signature (tamper detection)
-        const isValid = await verifySignature(state);
-        if (!isValid) {
-            console.warn('Rate limit state tampered, resetting');
-            return null;
-        }
         
         // Check if lockout has expired
         const now = Date.now();
@@ -139,7 +76,6 @@ export async function recordFailedAttempt(account: string): Promise<RateLimitSta
             attempts: 1,
             lastAttempt: now,
             lockedUntil: null,
-            signature: '',
         };
     } else if (state.lockedUntil) {
         // Already locked, extend lockout
@@ -155,10 +91,6 @@ export async function recordFailedAttempt(account: string): Promise<RateLimitSta
             state.lockedUntil = now + LOCKOUT_DURATION_MS;
         }
     }
-    
-    // Generate signature
-    const { signature, ...unsignedState } = state;
-    state.signature = await generateSignature(unsignedState);
     
     // Persist
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The client-side rate limiter (`src/lib/rateLimiter.ts`) utilized an HMAC key to sign its state, ostensibly to prevent tampering. However, it persisted both the state AND the dynamically generated HMAC key in plaintext `localStorage`. This creates a false sense of security (security theater) as an attacker with access to modify `localStorage` state inherently has access to read the signing key and forge a valid signature for their tampered data.
🎯 Impact: This provides no meaningful tamper-resistance and falsely conveys that the rate limiting mechanism is secure against client-side manipulation, when it fundamentally is just a client-side deterrent.
🛠️ Fix: Removed the superficial HMAC signing and verification logic from `RateLimitState` and tests, simplifying the codebase and acknowledging the client-side nature of the limit.
✅ Verification: `pnpm test src/lib/rateLimiter.test.ts` passes with updated, cleaner logic. Documentation added to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16374992532335532647](https://jules.google.com/task/16374992532335532647) started by @njtan142*