### PR TITLE
⚡ Bolt: [performance improvement] Replace array spread with for loop to prevent call stack overflow

### DIFF
--- a/src/features/ledger/SchemaBuilder.tsx
+++ b/src/features/ledger/SchemaBuilder.tsx
@@ -35,7 +35,6 @@ export const SchemaBuilder: React.FC<SchemaBuilderProps> = ({ projectId, onClose
         isLoading,
         editingSchemaId,
         initCreate,
-        setDraftName,
         addField,
         removeField,
         updateField,

--- a/src/services/nodeEngine.ts
+++ b/src/services/nodeEngine.ts
@@ -76,7 +76,11 @@ class NodeEngine {
                             const sourceData = nodeResults.get(edge.source);
                             const val = sourceData?.[edge.sourceHandle!];
                             if (Array.isArray(val)) {
-                                inputValues.push(...val);
+                                // ⚡ Bolt: Use for-loop instead of push(...val) to avoid "Maximum call stack size exceeded"
+                                // errors and improve performance when dealing with large datasets.
+                                for (let i = 0; i < val.length; i++) {
+                                    inputValues.push(val[i]);
+                                }
                             } else if (typeof val === 'number') {
                                 inputValues.push(val);
                             }


### PR DESCRIPTION
💡 **What:** Replaced the array spread operator (`...val`) inside `Array.prototype.push()` with an explicit `for` loop in `src/services/nodeEngine.ts`.
🎯 **Why:** JavaScript engines limit the maximum number of arguments in a function call (often to ~65k-100k). When processing large ledgers, spreading an array with hundreds of thousands of entries into `.push()` causes the application to crash with a "Maximum call stack size exceeded" exception. Using a `for` loop averts this entirely while achieving the same result.
📊 **Impact:** Prevents fatal application crashes on extremely large dataset computations and provides minor CPU execution improvements in V8 by bypassing intermediate spread allocations.
🔬 **Measurement:** Can be verified by running `nodeEngine.executeProjectGraph()` with a connected ledger source containing >150k numeric entries and ensuring it completes successfully without crashing the computation pass.

---
*PR created automatically by Jules for task [14823989951022013768](https://jules.google.com/task/14823989951022013768) started by @njtan142*