### PR TITLE
🎨 Palette: Fix hardcoded dark theme classes

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -54,7 +54,7 @@ export const CommandPalette: React.FC = () => {
                     <CommandGroup heading="Actions">
                         {projectId && (
                             <CommandItem onSelect={() => runCommand(() => navigate(`/app/${profileId}/project/${projectId}/node-forge`))}>
-                                <Network className="mr-2 h-4 w-4 text-zinc-400" />
+                                <Network className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                                 <span>Open Node Forge for this Project</span>
                             </CommandItem>
                         )}
@@ -63,17 +63,17 @@ export const CommandPalette: React.FC = () => {
                                 // Trigger the "Add Entry" UI in LedgerTable via the N shortcut
                                 window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n' }));
                             })}>
-                                <Plus className="mr-2 h-4 w-4 text-zinc-400" />
+                                <Plus className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                                 <span>New Entry in this Ledger</span>
                                 <CommandShortcut>N</CommandShortcut>
                             </CommandItem>
                         )}
                         <CommandItem onSelect={() => runCommand(() => setSchemaBuilderOpen(true))}>
-                            <Database className="mr-2 h-4 w-4 text-zinc-400" />
+                            <Database className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                             <span>Create New Ledger Schema...</span>
                         </CommandItem>
                         <CommandItem onSelect={() => runCommand(() => navigate(`/app/${profileId}/projects`))}>
-                            <FolderKanban className="mr-2 h-4 w-4 text-zinc-400" />
+                            <FolderKanban className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                             <span>Create New Project...</span>
                         </CommandItem>
                     </CommandGroup>
@@ -89,7 +89,7 @@ export const CommandPalette: React.FC = () => {
                                     navigate(`/app/${profileId}/project/${project._id}`);
                                 })}
                             >
-                                <LayoutGrid className="mr-2 h-4 w-4 text-zinc-400" />
+                                <LayoutGrid className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                                 <span>{project.name}</span>
                                 {projectId === project._id && (
                                     <Badge variant="secondary" className="ml-auto bg-emerald-500/10 text-emerald-500 border-emerald-500/30 text-[10px] font-bold uppercase">
@@ -115,7 +115,7 @@ export const CommandPalette: React.FC = () => {
                                     }
                                 })}
                             >
-                                <Database className="mr-2 h-4 w-4 text-zinc-400" />
+                                <Database className="mr-2 h-4 w-4 text-zinc-500 dark:text-zinc-400" />
                                 <span>{schema.name}</span>
                             </CommandItem>
                         ))}
@@ -135,7 +135,7 @@ export const CommandPalette: React.FC = () => {
                         >
                             <Badge
                                 variant="ghost"
-                                className={`w-2 h-2 rounded-full mr-3 ${profile.id === profileId ? 'bg-emerald-500' : 'bg-zinc-700'}`}
+                                className={`w-2 h-2 rounded-full mr-3 ${profile.id === profileId ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-700'}`}
                             />
                             <span>{profile.name}</span>
                         </CommandItem>

--- a/src/features/dashboard/EmptyDashboard.tsx
+++ b/src/features/dashboard/EmptyDashboard.tsx
@@ -9,11 +9,11 @@ interface EmptyDashboardProps {
 export const EmptyDashboard: React.FC<EmptyDashboardProps> = ({ onActionClick }) => {
     return (
         <div className="flex flex-col items-center justify-center p-8 bg-white dark:bg-zinc-950/50 rounded-2xl border border-zinc-300 dark:border-zinc-900 border-dashed text-center w-full max-w-lg">
-            <div className="w-16 h-16 bg-zinc-900 rounded-full flex items-center justify-center mb-6">
+            <div className="w-16 h-16 bg-gray-100 dark:bg-zinc-900 rounded-full flex items-center justify-center mb-6">
                 <Sparkles size={32} className="text-emerald-500" aria-hidden="true" />
             </div>
-            <h2 className="text-2xl font-bold text-zinc-100 mb-2">Welcome to Ledgy!</h2>
-            <p className="text-zinc-400 max-w-sm mb-8">
+            <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100 mb-2">Welcome to Ledgy!</h2>
+            <p className="text-zinc-600 dark:text-zinc-400 max-w-sm mb-8">
                 Create your first ledger to get started tracking your data securely and privately.
             </p>
             <Button

--- a/src/features/nodeEditor/EmptyCanvasGuide.tsx
+++ b/src/features/nodeEditor/EmptyCanvasGuide.tsx
@@ -20,7 +20,7 @@ export const EmptyCanvasGuide: React.FC<EmptyCanvasGuideProps> = ({ onAddFirstNo
                     <h2 className="text-2xl font-bold text-emerald-400 mb-4">
                         Welcome to Node Forge
                     </h2>
-                    <p className="text-zinc-400 mb-6">
+                    <p className="text-zinc-500 dark:text-zinc-400 mb-6">
                         Create visual automations by connecting data sources to logic nodes. Let's get started.
                     </p>
 
@@ -43,7 +43,7 @@ export const EmptyCanvasGuide: React.FC<EmptyCanvasGuideProps> = ({ onAddFirstNo
                                 </CardContent>
                             </Card>
                             <div>
-                                <h3 className="font-medium text-sm text-zinc-300">Connect Nodes</h3>
+                                <h3 className="font-medium text-sm text-zinc-700 dark:text-zinc-300">Connect Nodes</h3>
                                 <p className="text-xs text-zinc-500">Drag from output ports to inputs</p>
                             </div>
                         </div>
@@ -55,8 +55,8 @@ export const EmptyCanvasGuide: React.FC<EmptyCanvasGuideProps> = ({ onAddFirstNo
                                 </CardContent>
                             </Card>
                             <div>
-                                <h3 className="font-medium text-sm text-zinc-300">Navigate Canvas</h3>
-                                <p className="text-xs text-zinc-500">Hold <kbd className="px-1.5 py-0.5 bg-gray-100 dark:bg-zinc-800 rounded text-[10px] text-zinc-300 border border-zinc-300 dark:border-zinc-700">Space</kbd> + drag to pan</p>
+                                <h3 className="font-medium text-sm text-zinc-700 dark:text-zinc-300">Navigate Canvas</h3>
+                                <p className="text-xs text-zinc-500">Hold <kbd className="px-1.5 py-0.5 bg-gray-100 dark:bg-zinc-800 rounded text-[10px] text-zinc-700 dark:text-zinc-300 border border-zinc-300 dark:border-zinc-700">Space</kbd> + drag to pan</p>
                             </div>
                         </div>
                     </div>

--- a/src/features/nodeEditor/nodes/ContainerNode.tsx
+++ b/src/features/nodeEditor/nodes/ContainerNode.tsx
@@ -185,15 +185,15 @@ export const ContainerNode: React.FC<NodeProps> = React.memo(({
             <div 
                 className={`
                     w-full h-full rounded-lg border-2 overflow-hidden
-                    ${selected ? 'border-emerald-500' : 'border-zinc-700'}
-                    bg-zinc-900/50
+                    ${selected ? 'border-emerald-500' : 'border-zinc-300 dark:border-zinc-700'}
+                    bg-gray-50/50 dark:bg-zinc-900/50
                     transition-colors duration-150
                 `}
             >
                 {/* Header */}
                 <div
                     ref={headerRef}
-                    className="container-header flex items-center justify-between px-3 py-2 bg-zinc-800 border-b border-zinc-700 cursor-pointer"
+                    className="container-header flex items-center justify-between px-3 py-2 bg-gray-100 dark:bg-zinc-800 border-b border-zinc-300 dark:border-zinc-700 cursor-pointer"
                     onDoubleClick={handleHeaderDoubleClick}
                     onClick={isEditing ? undefined : startEditing}
                     onKeyDown={handleKeyDown}
@@ -203,7 +203,7 @@ export const ContainerNode: React.FC<NodeProps> = React.memo(({
                     aria-label={`Group: ${label}`}
                 >
                     <div className="flex items-center gap-2 flex-1 min-w-0">
-                        <FolderOpen size={14} className="text-zinc-400 flex-shrink-0" />
+                        <FolderOpen size={14} className="text-zinc-600 dark:text-zinc-400 flex-shrink-0" />
                         
                         {isEditing ? (
                             <input
@@ -214,11 +214,11 @@ export const ContainerNode: React.FC<NodeProps> = React.memo(({
                                 onBlur={saveLabel}
                                 onKeyDown={handleInputKeyDown}
                                 onClick={(e) => e.stopPropagation()}
-                                className="flex-1 bg-zinc-700 text-zinc-100 text-sm px-1 py-0.5 rounded border border-emerald-500 outline-none min-w-0"
+                                className="flex-1 bg-gray-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 text-sm px-1 py-0.5 rounded border border-emerald-500 outline-none min-w-0"
                                 maxLength={50}
                             />
                         ) : (
-                            <span className="text-sm font-medium text-zinc-100 truncate">
+                            <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
                                 {label}
                             </span>
                         )}
@@ -227,13 +227,13 @@ export const ContainerNode: React.FC<NodeProps> = React.memo(({
                     {/* Collapse/Expand Button */}
                     <button
                         onClick={handleToggle}
-                        className="p-1 rounded hover:bg-zinc-700 transition-colors flex-shrink-0"
+                        className="p-1 rounded hover:bg-gray-200 dark:bg-zinc-700 transition-colors flex-shrink-0"
                         aria-label={isCollapsed ? 'Expand group' : 'Collapse group'}
                         title={isCollapsed ? 'Expand' : 'Collapse'}
                     >
                         <ChevronDown 
                             size={16} 
-                            className={`chevron-icon ${isCollapsed ? 'collapsed' : 'expanded'} text-zinc-400`}
+                            className={`chevron-icon ${isCollapsed ? 'collapsed' : 'expanded'} text-zinc-600 dark:text-zinc-400`}
                         />
                     </button>
                 </div>


### PR DESCRIPTION
🎨 Palette: fix hardcoded dark theme classes without light alternatives

💡 What: Updated hardcoded dark-mode specific Tailwind classes across `ContainerNode`, `EmptyCanvasGuide`, `EmptyDashboard`, and `CommandPalette` to use paired light/dark variants (e.g. `bg-gray-50 dark:bg-zinc-900`).
🎯 Why: Elements with hardcoded `text-zinc-100` or `bg-zinc-900` without a light mode fallback fail contrast checks and become unreadable when the application is viewed in light mode. This restores accessibility for light theme users.
📸 Before/After: Text and backgrounds now dynamically adjust, passing the `themeRegression.test.ts`.
♿ Accessibility: Improved contrast ratio in light mode for all updated components.

---
*PR created automatically by Jules for task [14702444983366388013](https://jules.google.com/task/14702444983366388013) started by @njtan142*