### PR TITLE
🎨 Palette: Add aria-pressed and aria-labels to Inspector toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-02-23 - Accessibility of Persistent State Icon Toggles
+**Learning:** Icon-only toggle buttons used for selecting persistent states (like 'widgetType' or 'eventType' in the Node Inspector) require both `aria-label` for identity and `aria-pressed` for current state selection. Missing `aria-pressed` makes it impossible for screen reader users to identify which option is currently active in a button group.
+**Action:** When implementing button groups acting as tab-switchers or state toggles, unconditionally ensure `aria-pressed={isActive}` is applied alongside a descriptive `aria-label`.

--- a/src/components/Inspector/NodeInspector.tsx
+++ b/src/components/Inspector/NodeInspector.tsx
@@ -188,6 +188,7 @@ const TriggerPanel: React.FC<{ id: string; data: any }> = ({ id, data }) => {
                             variant={data.eventType === ev ? 'default' : 'outline'}
                             className={data.eventType === ev ? 'bg-emerald-600 border-emerald-500 text-zinc-900 dark:text-white' : 'text-zinc-400'}
                             onClick={() => useNodeStore.getState().updateNodeData(id, { eventType: ev })}
+                            aria-pressed={data.eventType === ev}
                         >
                             {ev === 'on-create' ? 'On Create' : 'On Edit'}
                         </Button>
@@ -251,6 +252,8 @@ const DashboardOutputPanel: React.FC<{ id: string; data: any }> = ({ id, data })
                             className={data.widgetType === wt ? `${color} text-zinc-900 dark:text-white` : 'text-zinc-400'}
                             title={wt}
                             onClick={() => handleWidgetType(wt)}
+                            aria-label={`${wt} widget type`}
+                            aria-pressed={data.widgetType === wt}
                         >
                             {icon}
                         </Button>


### PR DESCRIPTION
**🎨 Palette: [UX improvement] Add aria-pressed to toggle buttons in Node Inspector**

💡 **What:** Added `aria-pressed` state attributes to the `eventType` and `widgetType` toggle button groups in `NodeInspector.tsx`, as well as a descriptive `aria-label` to the icon-only `widgetType` buttons.
🎯 **Why:** To ensure screen reader users can identify both the purpose of the icon-only buttons and clearly understand which option is currently selected in the state-switching button groups.
♿ **Accessibility:** Solves a critical accessibility gap where persistent selection state was conveyed visually via CSS background colors but completely omitted from screen reader announcements.

---
*PR created automatically by Jules for task [6988825049607642821](https://jules.google.com/task/6988825049607642821) started by @njtan142*