### PR TITLE
🎨 Palette: [UX improvement] Add aria-expanded to layout toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-18 - ARIA Expanded for Layout Toggles
+**Learning:** Collapsible layout regions (like a left sidebar or right inspector rail) often have toggle buttons whose visually apparent state (e.g., an icon changing from `ChevronLeft` to `ChevronRight`) is not automatically conveyed to assistive technologies.
+**Action:** For layout toggle buttons that show or hide sections, explicitly add and dynamically bind the `aria-expanded` attribute to the boolean visibility state of the target panel (e.g., `aria-expanded={isOpen}`) to communicate the expanded/collapsed state to screen readers.

--- a/src/features/shell/InspectorRail.tsx
+++ b/src/features/shell/InspectorRail.tsx
@@ -30,6 +30,7 @@ export const InspectorRail = () => {
                     size="icon-xs"
                     className="text-zinc-400"
                     aria-label="Collapse inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronRight className="w-4 h-4" />
                 </Button>
@@ -64,6 +65,7 @@ export const InspectorRail = () => {
                     size="icon-sm"
                     className="rounded-full bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md text-zinc-400"
                     aria-label="Expand inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar = () => {
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Collapse sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -63,7 +64,7 @@ export const Sidebar = () => {
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
                     aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -103,6 +104,7 @@ export const Sidebar = () => {
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Expand sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-expanded` attributes to the layout toggle buttons for the Sidebar and Inspector Rail components.
🎯 **Why:** To improve accessibility for screen reader users by programmatically communicating the expanded or collapsed state of these main layout regions. Previously, these icon-only buttons lacked the `aria-expanded` state, leaving their structural impact invisible to assistive technologies.
📸 **Before/After:** The UI remains visually identical, but screen readers will now announce "expanded" or "collapsed" based on the panel's visibility state.
♿ **Accessibility:** Enhances WCAG compliance for collapsible regions by providing an explicit ARIA state on the trigger controls.

---
*PR created automatically by Jules for task [10689106365046691823](https://jules.google.com/task/10689106365046691823) started by @njtan142*