### PR TITLE
🎨 Palette: Add aria attributes to top bar icon toggle buttons

### DIFF
--- a/src/components/Inspector/Inspector.tsx
+++ b/src/components/Inspector/Inspector.tsx
@@ -24,6 +24,7 @@ import { Info, X } from 'lucide-react';
                     onClick={() => setRightInspector(false)}
                     className="p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg text-zinc-500 transition-colors"
                     aria-label="Close Inspector"
+                    aria-expanded={true}
                  >
                     <X size={16} />
                  </Button>

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 **What:**
Added `aria-expanded` and `aria-pressed` states to the icon-only view toggle buttons in the AppShell (Sidebar, Theme, Dashboard View Mode, Inspector) and the Inspector component itself.

🎯 **Why:**
While the buttons possessed basic `aria-label`s, they were functioning as toggleable state switches. Screen readers had no programmatic way to determine if the sidebars were open/closed or if the dark mode / grid view was currently active. Adding `aria-expanded` and `aria-pressed` explicitly communicates this state.

♿ **Accessibility:**
Provides accurate, dynamic state tracking for all primary structural toggle buttons in the app shell, aligning with the pattern established in the `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [15261697239054663767](https://jules.google.com/task/15261697239054663767) started by @njtan142*