### PR TITLE
🎨 Palette: Add aria-expanded to layout toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2025-02-28 - Dynamic aria-expanded for Layout Toggle Buttons
+**Learning:** Found an accessibility issue pattern in the `AppShell` component where the sidebar and inspector layout toggle buttons had `aria-label`s but lacked the necessary `aria-expanded` attributes to communicate their open/close state to screen readers dynamically.
+**Action:** Next time I encounter layout toggle buttons (like sidebars, inspectors, or collapsible panels), I must explicitly add and bind the `aria-expanded` attribute to the boolean visibility state of the target panel to ensure the expanded/collapsed state is correctly communicated to assistive technologies.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -457,6 +458,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
🎨 Palette: Add aria-expanded to AppShell layout toggle buttons

💡 What: Added the `aria-expanded` attribute to the Left Sidebar and Right Inspector toggle buttons in the `AppShell` component.
🎯 Why: Layout toggle buttons need to communicate their current state (expanded vs collapsed) to screen readers. Relying solely on `aria-label` changing between "Open" and "Close" is insufficient for robust accessibility.
📸 Before/After: Visuals are unaffected.
♿ Accessibility: Screen readers will now correctly announce when the left sidebar or right inspector panels are expanded or collapsed, conforming to WAI-ARIA authoring practices for disclosure widgets/buttons.

---
*PR created automatically by Jules for task [13424676008577247577](https://jules.google.com/task/13424676008577247577) started by @njtan142*