### PR TITLE
⚡ Bolt: [performance improvement] O(1) Schema Lookup in BackLinksPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-05-28 - Optimize Schema Lookup in List Rendering
+**Learning:** Using `Array.prototype.find` to look up referenced data (like a schema) inside a list item component (e.g., `BackLinkItem`) creates an O(L*N) rendering complexity where L is the number of lookup items and N is the number of rendered items.
+**Action:** When rendering a list of components where each item performs a lookup from a shared array, memoize the array into a `Map` in the parent component using `useMemo` and pass the `Map` as a prop. This reduces lookup complexity to O(1) per item, improving overall rendering to O(L+N).

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -20,8 +20,15 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     targetEntryId,
     targetLedgerId,
 }) => {
-    const { backLinks, fetchBackLinks } = useLedgerStore();
+    const { backLinks, fetchBackLinks, schemas } = useLedgerStore();
     const { activeProfileId } = useProfileStore();
+
+    // ⚡ Bolt: Memoize schema lookup Map to change rendering complexity from O(L*N) to O(L+N)
+    const schemasMap = React.useMemo(() => {
+        const map = new Map();
+        schemas.forEach(s => map.set(s._id, s));
+        return map;
+    }, [schemas]);
 
     useEffect(() => {
         if (activeProfileId && targetEntryId) {
@@ -50,6 +57,7 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
                         entry={entry}
                         targetEntryId={targetEntryId}
                         targetLedgerId={targetLedgerId}
+                        schemasMap={schemasMap}
                     />
                 ))}
             </div>
@@ -61,15 +69,15 @@ interface BackLinkItemProps {
     entry: LedgerEntry;
     targetEntryId: string;
     targetLedgerId: string;
+    schemasMap: Map<string, any>;
 }
 
-const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => {
-    const { schemas } = useLedgerStore();
+const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId, schemasMap }) => {
     const { profileId } = useParams<{ profileId: string }>();
     const { activeProfileId } = useProfileStore();
 
     // Find the schema for this entry's ledger
-    const entrySchema = schemas.find(s => s._id === entry.schemaId);
+    const entrySchema = schemasMap.get(entry.schemaId);
     const ledgerName = entrySchema?.name || entry.ledgerId;
 
     // Find which fields in this entry reference the target


### PR DESCRIPTION
💡 What:
Replaced the O(N) array search (`schemas.find`) inside the `BackLinkItem` rendering loop with an O(1) `Map` lookup (`schemasMap.get`) computed in the parent `BackLinksPanel` using `useMemo`.

🎯 Why:
The `BackLinksPanel` iterates over all referenced entries (back-links) and renders a `BackLinkItem` for each. Inside `BackLinkItem`, `schemas.find` was previously used to locate the schema for the entry. For a large number of back-links (N) and many schemas (L), this resulted in O(L*N) rendering complexity, which could cause sluggishness.

📊 Impact:
Reduces schema lookup complexity from O(L*N) to O(L+N) during the rendering of the back-links list, minimizing main thread blocking and ensuring smoother interaction when viewing highly-referenced entries.

🔬 Measurement:
1. Load a ledger with many entries and references.
2. Select an entry with numerous back-links in the Node Inspector.
3. Observe faster rendering and expansion of the BackLinksPanel.

---
*PR created automatically by Jules for task [9958014925952101856](https://jules.google.com/task/9958014925952101856) started by @njtan142*