### PR TITLE
⚡ Bolt: Replace map/filter chains and spread with single-pass loop

### DIFF
--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,29 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            let sum = 0;
+            let min = Infinity;
+            let max = -Infinity;
+            let count = 0;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const val = entries[i].data[fieldId];
+                if (typeof val === 'number' && !isNaN(val)) {
+                    sum += val;
+                    if (val < min) min = val;
+                    if (val > max) max = val;
+                    count++;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min,
+                    max,
+                    count,
                 };
             }
         });
@@ -201,17 +212,28 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
+
+        for (let i = 0; i < entries.length; i++) {
+            const val = entries[i].data[fieldId];
+            if (typeof val === 'number' && !isNaN(val)) {
+                sum += val;
+                if (val < min) min = val;
+                if (val > max) max = val;
+                count++;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min,
+            max,
+            count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
💡 **What:** Optimized statistical calculations (`avg`, `min`, `max`, `count`) in `useLedgerSourceData` and `useFieldStats` by replacing chained array methods and spread operators with explicit, single-pass `for` loops.

🎯 **Why:** 
1. `Math.min(...values)` and `Math.max(...values)` use the spread operator, which passes each array item as an argument. In V8, exceeding the argument limit (~65k-120k items) throws a `Maximum call stack size exceeded` error, crashing the app on large ledger sets.
2. Chained `.map().filter()` calls create redundant O(N) passes and allocate intermediate arrays, increasing memory pressure and triggering GC pauses.

📊 **Impact:** 
- Eliminates the risk of stack overflow crashes on large data nodes.
- Reduces lookup complexity by minimizing intermediate allocations, resulting in faster and more stable performance during real-time data preview rendering.

🔬 **Measurement:**
- Verified by checking that UI components relying on these stats (like `LedgerSourceNode`) render correctly.
- Run `pnpm test` to ensure regressions were not introduced.

---
*PR created automatically by Jules for task [13492723196959526927](https://jules.google.com/task/13492723196959526927) started by @njtan142*