### PR TITLE
🎨 Palette: Add aria-expanded to layout toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2025-05-09 - Importance of Dynamic `aria-expanded` for Structural Layout Panels
+**Learning:** Layout toggle buttons that control structural side panels (like sidebars and inspectors) are often lacking proper `aria-expanded` attributes, which fails to communicate the expanded/collapsed state to screen reader users. Simply adding an `aria-label` is not enough to relay current visibility state.
+**Action:** When implementing or refactoring layout toggle buttons that show or hide sections, always explicitly add and dynamically bind the `aria-expanded` attribute to the boolean visibility state of the target panel (e.g., `aria-expanded={isOpen}`).

--- a/src/features/shell/InspectorRail.tsx
+++ b/src/features/shell/InspectorRail.tsx
@@ -30,6 +30,7 @@ export const InspectorRail = () => {
                     size="icon-xs"
                     className="text-zinc-400"
                     aria-label="Collapse inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronRight className="w-4 h-4" />
                 </Button>
@@ -64,6 +65,7 @@ export const InspectorRail = () => {
                     size="icon-sm"
                     className="rounded-full bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md text-zinc-400"
                     aria-label="Expand inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar = () => {
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Collapse sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -63,7 +64,7 @@ export const Sidebar = () => {
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
                     aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -103,6 +104,7 @@ export const Sidebar = () => {
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Expand sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>


### PR DESCRIPTION
💡 **What**: Added `aria-expanded` attributes to the toggle buttons for the left Sidebar and right Inspector panels, dynamically binding them to the `sidebarOpen` and `inspectorOpen` state variables.
🎯 **Why**: Previously, these icon-only layout buttons only had an `aria-label` (and the mobile one had a hardcoded `aria-expanded="false"`). Screen reader users couldn't tell if activating the button would open or close the panel because the current expanded state wasn't communicated.
📸 **Before/After**: N/A - Visually identical.
♿ **Accessibility**: Improves state communication for structural layout panels, allowing screen readers to accurately announce whether the Sidebar or Inspector is currently expanded or collapsed.

---
*PR created automatically by Jules for task [13887015698369231719](https://jules.google.com/task/13887015698369231719) started by @njtan142*