### PR TITLE
⚡ Bolt: [performance improvement] Hoist sort metadata in LedgerTable

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2025-05-23 - Avoid redundant map lookups in Array.prototype.sort
+**Learning:** In list rendering components like `LedgerTable`, repeatedly calling `Array.prototype.find` on a schema array inside a `.sort()` comparator creates $O(N \log N \cdot F)$ complexity, where $N$ is the number of items and $F$ is the number of fields.
+**Action:** When sorting data based on external metadata (like a schema configuration), map the sort configuration to an array of objects containing the pre-resolved metadata once before the sort operation. This hoists the $O(F)$ lookup out of the comparator, reducing redundant searches and avoiding unnecessary re-renders or main thread blocking on large datasets.

--- a/src/features/ledger/LedgerTable.tsx
+++ b/src/features/ledger/LedgerTable.tsx
@@ -99,9 +99,16 @@ export const LedgerTable: React.FC<LedgerTableProps> = ({ schemaId, highlightEnt
     const sortedEntries = useMemo(() => {
         if (sortConfig.length === 0) return flattenedLedgerEntries;
 
+        // ⚡ Bolt: Hoist metadata lookups out of the O(N log N) sort comparator
+        // to avoid redundant O(F) searches for each item comparison
+        const sortMetadata = sortConfig.map(({ field, direction }) => ({
+            field,
+            direction,
+            schemaField: schema?.fields.find(f => f.name === field)
+        }));
+
         return [...flattenedLedgerEntries].sort((a, b) => {
-            for (const { field, direction } of sortConfig) {
-                const schemaField = schema?.fields.find(f => f.name === field);
+            for (const { field, direction, schemaField } of sortMetadata) {
                 const aVal = a.data[field];
                 const bVal = b.data[field];
 


### PR DESCRIPTION
💡 **What:** Hoists schema field lookups out of the `.sort()` comparator loop in `LedgerTable.tsx`.
🎯 **Why:** Previously, the sort logic iteratively searched the schema's field array for *every* item comparison (resulting in $O(N \log N \cdot F)$ complexity), which could degrade UI performance on large ledger datasets. By caching the lookup metadata in an outer map, the complexity drops drastically.
📊 **Impact:** Reduces redundant schema field searches from $O(N \log N)$ executions to just $O(\text{number of sort columns})$, improving sorting responsiveness for large lists.
🔬 **Measurement:** Verify sorting behavior is identical and observe lower main-thread execution time while re-sorting.

---
*PR created automatically by Jules for task [16616105040648644180](https://jules.google.com/task/16616105040648644180) started by @njtan142*