### PR TITLE
🎨 Palette: Add dynamic aria-expanded attributes to layout toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-02-23 - ARIA Expanded for Layout Toggles
+**Learning:** Layout toggle buttons that show or hide panels (like sidebars and inspectors) often lack explicit screen-reader feedback about their state. Adding an `aria-expanded` attribute directly tied to the visibility state variables (e.g., `inspectorOpen`, `sidebarOpen`) drastically improves keyboard navigation and screen-reader context for these structural elements.
+**Action:** Always verify that layout toggle buttons (like those found in `Sidebar.tsx` and `InspectorRail.tsx`) have `aria-expanded` bound to the open/closed state variable of their target panel, rather than hardcoded string values or entirely omitted.

--- a/src/features/nodeEditor/components/ConnectionLine.tsx
+++ b/src/features/nodeEditor/components/ConnectionLine.tsx
@@ -22,7 +22,7 @@ type ConnectionStatus = 'valid' | 'invalid' | 'default' | 'snapped';
 /**
  * Extended props including connection status and direction
  */
-interface ExtendedConnectionLineProps extends ConnectionLineComponentProps {
+interface ExtendedConnectionLineProps extends Omit<ConnectionLineComponentProps, 'connectionStatus'> {
     connectionStatus?: ConnectionStatus;
     sourceDirection?: 'left' | 'right' | 'top' | 'bottom';
 }

--- a/src/features/shell/InspectorRail.tsx
+++ b/src/features/shell/InspectorRail.tsx
@@ -30,6 +30,7 @@ export const InspectorRail = () => {
                     size="icon-xs"
                     className="text-zinc-400"
                     aria-label="Collapse inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronRight className="w-4 h-4" />
                 </Button>
@@ -64,6 +65,7 @@ export const InspectorRail = () => {
                     size="icon-sm"
                     className="rounded-full bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md text-zinc-400"
                     aria-label="Expand inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar = () => {
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Collapse sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -63,7 +64,7 @@ export const Sidebar = () => {
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
                     aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -103,6 +104,7 @@ export const Sidebar = () => {
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Expand sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>


### PR DESCRIPTION
💡 **What**: Added `aria-expanded` attributes to the Sidebar and InspectorRail toggle buttons, dynamically binding them to the `sidebarOpen` and `inspectorOpen` state variables. Fixed an existing bug where the mobile hamburger menu had a hardcoded `aria-expanded="false"`.

🎯 **Why**: When layout panels (like sidebars and property inspectors) expand or collapse, screen reader users need programmatic confirmation of the panel's visibility state. Without `aria-expanded`, these icon-only buttons only provide a label, not their current structural state.

📸 **Before/After**: 
- Before: `<button aria-label="Expand sidebar">`
- After: `<button aria-label="Expand sidebar" aria-expanded={sidebarOpen}>`

♿ **Accessibility**: Greatly improves structural navigation context for screen readers traversing the main AppShell layout.

---
*PR created automatically by Jules for task [5688659022671957377](https://jules.google.com/task/5688659022671957377) started by @njtan142*