### PR TITLE
⚡ Bolt: Replace map/filter chains and spread syntax with for loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2025-02-12 - Prevent Spread Call Stack Exceptions on Large Datasets
+**Learning:** Using spread syntax (`Math.min(...values)` or `Math.max(...values)`) is dangerous for performance and stability on large arrays, as V8 limits call stack size and this will throw 'Maximum call stack size exceeded' exceptions on big datasets.
+**Action:** When computing stats or manipulating large dynamic arrays, explicitly avoid using spread operators and instead opt for single-pass `for` loops, which have no stack limit and are generally more performant by avoiding O(N) array allocation.

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,31 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            // ⚡ Bolt: Replaced chained .map().filter() and spread Math.min/max with a single-pass loop
+            // Reduces memory allocations and avoids V8 call stack size errors on large arrays
+            let sum = 0;
+            let min = Infinity;
+            let max = -Infinity;
+            let count = 0;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const val = entries[i].data[fieldId];
+                if (typeof val === 'number' && !isNaN(val)) {
+                    sum += val;
+                    if (val < min) min = val;
+                    if (val > max) max = val;
+                    count++;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min,
+                    max,
+                    count,
                 };
             }
         });
@@ -201,17 +214,30 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        // ⚡ Bolt: Replaced chained .map().filter() and spread Math.min/max with a single-pass loop
+        // Reduces memory allocations and avoids V8 call stack size errors on large arrays
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
+
+        for (let i = 0; i < entries.length; i++) {
+            const val = entries[i].data[fieldId];
+            if (typeof val === 'number' && !isNaN(val)) {
+                sum += val;
+                if (val < min) min = val;
+                if (val > max) max = val;
+                count++;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min,
+            max,
+            count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
💡 What: Replaced `.map().filter()` chained array allocations and `Math.min(...values)`/`Math.max(...values)` array spreading with a single-pass `for` loop in `src/features/nodeEditor/hooks/useLedgerSourceData.ts`.
🎯 Why: Spreading dynamically sized arrays with `Math.min/max` is unsafe as it can easily exceed the V8 call stack limit, leading to application crashes on large datasets. Chained operations also allocate O(N) temporary arrays.
📊 Impact: Completely eliminates the 'Maximum call stack size exceeded' exception risk on large inputs. Reduces O(N) array allocation overhead and multiple iteration passes to O(1) memory and single-pass iteration speed.
🔬 Measurement: Verify by rendering massive datasets into the ledger table—it will no longer crash and performance profiling will show reduced garbage collection sweeps.

---
*PR created automatically by Jules for task [651619426076616603](https://jules.google.com/task/651619426076616603) started by @njtan142*