### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix ReDoS vulnerability in schema builder

### DIFF
--- a/src/features/ledger/SchemaBuilder.tsx
+++ b/src/features/ledger/SchemaBuilder.tsx
@@ -1,3 +1,4 @@
+import { validateRegexPattern } from "../../utils/security";
 import React, { useEffect, useState } from 'react';
 import { useLedgerStore } from '../../stores/useLedgerStore';
 import { useProfileStore } from '../../stores/useProfileStore';
@@ -330,11 +331,10 @@ export const SchemaBuilder: React.FC<SchemaBuilderProps> = ({ projectId, onClose
                                                         onChange={(e) => updateField(index, { pattern: e.target.value === '' ? undefined : e.target.value })}
                                                         onBlur={(e) => {
                                                             if (e.target.value) {
-                                                                try {
-                                                                    new RegExp(e.target.value);
+                                                                if (validateRegexPattern(e.target.value)) {
                                                                     setPatternError(prev => ({ ...prev, [index]: null }));
-                                                                } catch {
-                                                                    setPatternError(prev => ({ ...prev, [index]: 'Invalid RegEx pattern' }));
+                                                                } else {
+                                                                    setPatternError(prev => ({ ...prev, [index]: 'Invalid or unsafe RegEx pattern' }));
                                                                 }
                                                             } else {
                                                                 setPatternError(prev => ({ ...prev, [index]: null }));

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,0 +1,31 @@
+/**
+ * Security utility functions
+ */
+
+/**
+ * Validates a user-provided regular expression pattern to prevent
+ * Regular Expression Denial of Service (ReDoS) vulnerabilities.
+ *
+ * Enforces a 250-character limit and uses a heuristic to block dangerous
+ * nested quantifiers (e.g., `(a+)+`) before compiling to RegExp.
+ */
+export function validateRegexPattern(pattern: string): boolean {
+    if (!pattern) return true;
+
+    // Hard limit on pattern length to prevent excessively large compilation
+    if (pattern.length > 250) return false;
+
+    // Heuristic: reject nested quantifiers like (a+)+ which can cause ReDoS
+    // Carefully designed to not flag valid lazy quantifiers like *?
+    const nestedQuantifierRegex = /\([^)]*(?:[+*]|\{\d+(?:,\d*)?\})[^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/;
+    if (nestedQuantifierRegex.test(pattern)) {
+        return false;
+    }
+
+    try {
+        new RegExp(pattern);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { validateRegexPattern } from '../src/utils/security';
+
+describe('validateRegexPattern', () => {
+    it('allows valid basic patterns', () => {
+        expect(validateRegexPattern('^[A-Z]')).toBe(true);
+        expect(validateRegexPattern('abc')).toBe(true);
+    });
+
+    it('rejects nested quantifiers causing ReDoS', () => {
+        expect(validateRegexPattern('(a+)+')).toBe(false);
+        expect(validateRegexPattern('([a-z]+)*')).toBe(false);
+    });
+
+    it('rejects patterns that exceed the 250 character limit', () => {
+        const longPattern = 'a'.repeat(251);
+        expect(validateRegexPattern(longPattern)).toBe(false);
+    });
+
+    it('rejects invalid regex syntax', () => {
+        expect(validateRegexPattern('[unclosed')).toBe(false);
+    });
+});


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded user input was passed directly into `new RegExp(e.target.value)` inside the `SchemaBuilder.tsx` `onBlur` handler. Maliciously crafted regex patterns with nested quantifiers (like `(a+)+`) or excessively long patterns could cause a Regular Expression Denial of Service (ReDoS), locking up the main thread when evaluated.
🎯 **Impact:** An attacker could cause the client application to freeze or crash entirely by entering a malicious pattern into a text field's regex constraint configuration.
🔧 **Fix:** Introduced `src/utils/security.ts` with `validateRegexPattern`. This utility limits input to 250 characters and uses a safe heuristic regex `/\([^)]*(?:[+*]|\{\d+(?:,\d*)?\})[^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/` to block nested quantifiers before passing the string to `new RegExp()`. Applied this validation to `SchemaBuilder.tsx` instead of the raw `try/catch`.
✅ **Verification:** Added `tests/security.test.ts` to verify valid patterns are accepted, while oversized strings and nested quantifiers are safely rejected. Ran `pnpm test` and `pnpm run build` to ensure no regressions. Verified locally that ReDoS patterns trigger the "Invalid or unsafe RegEx pattern" validation error.

---
*PR created automatically by Jules for task [3324814359799804163](https://jules.google.com/task/3324814359799804163) started by @njtan142*