### PR TITLE
🎨 Palette: Add aria-expanded to layout toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-15 - Layout Toggle Accessibility
+**Learning:** Layout toggle buttons (like those for left/right sidebars or inspectors) need to explicitly communicate the expanded/collapsed state of their target panels to screen readers. Relying solely on visual cues (like changing icons or layout) leaves assistive tech users without context of the panel's state.
+**Action:** Always add and dynamically bind the `aria-expanded={isOpen}` attribute to the boolean visibility state of the target panel on toggle buttons that control layout sections.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -457,6 +458,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 **What:** Added `aria-expanded` attributes to the left sidebar and right inspector toggle buttons in the AppShell.
🎯 **Why:** To explicitly communicate the expanded/collapsed state of these layout panels to screen readers, improving accessibility. Relying solely on visual cues or changing icons leaves assistive tech users without context of the panel's state.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce the expanded state (true/false) of the left sidebar and right inspector toggle buttons.

---
*PR created automatically by Jules for task [8510302209973989079](https://jules.google.com/task/8510302209973989079) started by @njtan142*