### PR TITLE
⚡ Bolt: Optimize BackLinksPanel list rendering and schema lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2025-02-14 - Optimize BackLinksPanel list rendering
+**Learning:** When rendering lists where each item performs a lookup from a shared array or accesses a shared state hook, passing pre-computed values via props avoids O(L*N) complexity and prevents unnecessary per-item re-renders.
+**Action:** Hoist lookups and shared state out of the list item component. Use useMemo to convert arrays to Maps for O(1) lookups in child components. Also, iterate over schema fields instead of large data objects.

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { useLedgerStore } from '../../stores/useLedgerStore';
 import { useProfileStore } from '../../stores/useProfileStore';
-import { LedgerEntry } from '../../types/ledger';
+import { LedgerEntry, LedgerSchema } from '../../types/ledger';
 import { Link, useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
@@ -20,8 +20,9 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     targetEntryId,
     targetLedgerId,
 }) => {
-    const { backLinks, fetchBackLinks } = useLedgerStore();
+    const { backLinks, fetchBackLinks, schemas } = useLedgerStore();
     const { activeProfileId } = useProfileStore();
+    const { profileId } = useParams<{ profileId: string }>();
 
     useEffect(() => {
         if (activeProfileId && targetEntryId) {
@@ -30,6 +31,10 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     }, [activeProfileId, targetEntryId, fetchBackLinks]);
 
     const entries = backLinks[targetEntryId] || [];
+
+    // Pre-calculate schemas mapping for O(1) lookups in the children
+    const schemaMap = useMemo(() => new Map(schemas.map(s => [s._id, s])), [schemas]);
+    const navProfileId = profileId || activeProfileId;
 
     if (entries.length === 0) {
         return null;
@@ -50,6 +55,8 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
                         entry={entry}
                         targetEntryId={targetEntryId}
                         targetLedgerId={targetLedgerId}
+                        entrySchema={schemaMap.get(entry.schemaId)}
+                        navProfileId={navProfileId}
                     />
                 ))}
             </div>
@@ -61,24 +68,35 @@ interface BackLinkItemProps {
     entry: LedgerEntry;
     targetEntryId: string;
     targetLedgerId: string;
+    entrySchema?: LedgerSchema;
+    navProfileId?: string;
 }
 
-const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => {
-    const { schemas } = useLedgerStore();
-    const { profileId } = useParams<{ profileId: string }>();
-    const { activeProfileId } = useProfileStore();
-
-    // Find the schema for this entry's ledger
-    const entrySchema = schemas.find(s => s._id === entry.schemaId);
+const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId, entrySchema, navProfileId }) => {
     const ledgerName = entrySchema?.name || entry.ledgerId;
 
     // Find which fields in this entry reference the target
     const referencingFields: { fieldName: string; value: string | string[] }[] = [];
-    for (const [fieldName, value] of Object.entries(entry.data)) {
-        if (Array.isArray(value) && value.includes(targetEntryId)) {
-            referencingFields.push({ fieldName, value });
-        } else if (value === targetEntryId) {
-            referencingFields.push({ fieldName, value: [value] });
+
+    // Bolt Optimization: Pre-filter relation fields from schema to avoid looping large objects
+    if (entrySchema) {
+        const relationFields = entrySchema.fields.filter(f => f.type === 'relation');
+        for (const field of relationFields) {
+            const value = entry.data[field.name];
+            if (Array.isArray(value) && value.includes(targetEntryId)) {
+                referencingFields.push({ fieldName: field.name, value: value as string[] });
+            } else if (value === targetEntryId) {
+                referencingFields.push({ fieldName: field.name, value: [value as string] });
+            }
+        }
+    } else {
+        // Fallback if schema somehow not found
+        for (const [fieldName, value] of Object.entries(entry.data)) {
+            if (Array.isArray(value) && value.includes(targetEntryId)) {
+                referencingFields.push({ fieldName, value: value as string[] });
+            } else if (value === targetEntryId) {
+                referencingFields.push({ fieldName, value: [value as string] });
+            }
         }
     }
 
@@ -86,8 +104,6 @@ const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => 
     const displayValue = entrySchema?.fields.length
         ? String(entry.data[entrySchema.fields[0].name] || entry._id)
         : entry._id;
-
-    const navProfileId = profileId || activeProfileId;
 
     return (
         <Card className="p-3 bg-gray-100 dark:bg-zinc-800/30 rounded border border-zinc-300 dark:border-zinc-700 hover:border-zinc-600 transition-colors">

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -34,7 +34,7 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
 
     // Pre-calculate schemas mapping for O(1) lookups in the children
     const schemaMap = useMemo(() => new Map(schemas.map(s => [s._id, s])), [schemas]);
-    const navProfileId = profileId || activeProfileId;
+    const navProfileId = profileId || activeProfileId || undefined;
 
     if (entries.length === 0) {
         return null;


### PR DESCRIPTION
**💡 What**
I refactored `BackLinksPanel.tsx` by hoisting global store subscriptions (like `useLedgerStore` and `useProfileStore`) and route parameter hooks out of the mapped list item component (`BackLinkItem`). I also converted the schema array lookup to a memoized O(1) Map in the parent, passing the pre-computed schema directly to children. Lastly, I optimized the internal list logic to loop specifically over schema-defined `relation` fields instead of naively mapping all keys in `entry.data` with `Object.entries`.

**🎯 Why**
Previously, every single returned `BackLinkItem` (which could be numerous depending on entry links) was separately subscribing to the global store, getting router params, iterating through `Object.entries(entry.data)`, and looping through the global schema array to `find` its matching schema. This resulted in unnecessary per-item re-renders whenever unrelated state changed and created an O(L*N) bottleneck.

**📊 Impact**
Reduces React store subscription overhead by moving it to a single parent component instead of scaling with list items. Transforms O(L*N) schema lookups to O(L+N) by pre-computing a map. Further reduces redundant iteration over large data objects by explicitly targeting only `relation` typed schema fields.

**🔬 Measurement**
Run the test suite `pnpm test tests/BackLinksPanel.test.tsx` to verify standard component rendering. Open the application, create a ledger schema with numerous links, and measure component rendering traces (such as the React Profiler tree) to confirm fewer subscription mounts and faster initial panel layout execution.

---
*PR created automatically by Jules for task [4785990420255667443](https://jules.google.com/task/4785990420255667443) started by @njtan142*