### PR TITLE
🎨 Palette: Add accessibility attributes to toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-18 - [ARIA Expanded and Pressed Attributes]
+**Learning:** Icon-only state toggles (like theme switchers, view mode switchers, or sidebar collapse toggles) need explicit aria state attributes beyond just `aria-label`. Screen readers need `aria-pressed` for two-state toggles and `aria-expanded` for collapsible regions to accurately convey the current state to the user.
+**Action:** When adding or auditing icon-only buttons, check if they toggle a state (`aria-pressed={isActive}`) or expand/collapse a UI region (`aria-expanded={isOpen}`). Apply these attributes to ensure the state change is programmatically announced.

--- a/src/components/Inspector/NodeInspector.tsx
+++ b/src/components/Inspector/NodeInspector.tsx
@@ -188,6 +188,8 @@ const TriggerPanel: React.FC<{ id: string; data: any }> = ({ id, data }) => {
                             variant={data.eventType === ev ? 'default' : 'outline'}
                             className={data.eventType === ev ? 'bg-emerald-600 border-emerald-500 text-zinc-900 dark:text-white' : 'text-zinc-400'}
                             onClick={() => useNodeStore.getState().updateNodeData(id, { eventType: ev })}
+                            aria-label={ev}
+                            aria-pressed={data.eventType === ev}
                         >
                             {ev === 'on-create' ? 'On Create' : 'On Edit'}
                         </Button>
@@ -251,6 +253,8 @@ const DashboardOutputPanel: React.FC<{ id: string; data: any }> = ({ id, data })
                             className={data.widgetType === wt ? `${color} text-zinc-900 dark:text-white` : 'text-zinc-400'}
                             title={wt}
                             onClick={() => handleWidgetType(wt)}
+                            aria-label={wt}
+                            aria-pressed={data.widgetType === wt}
                         >
                             {icon}
                         </Button>

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 **What:** Added `aria-pressed` and `aria-expanded` attributes to icon-only toggle buttons and tab-like elements in `AppShell` and `NodeInspector`.
🎯 **Why:** To convey proper selection (pressed) and expanded/collapsed states to screen reader users, making the UI more accessible and compliant with ARIA standards for stateful toggle buttons.
📸 **Before/After:** Visual changes not applicable, screen-reader specific improvements in the DOM structure.
♿ **Accessibility:** Improved screen reader support for dashboards (view toggle), sidebars (collapse toggles), and node inspector toggles (widget types and events).

---
*PR created automatically by Jules for task [12032818202343032637](https://jules.google.com/task/12032818202343032637) started by @njtan142*