### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in Tauri file import

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** A redundant string-matching check for `https://` and `localhost` (`remoteUrl.startsWith`) was placed before a robust `URL` parsing block that correctly leveraged `isLocalNetwork`. This caused the application to mistakenly throw "HTTPS is required" errors for valid private network IPs (e.g., `192.168.x.x`), breaking self-hosted local-first sync workflows and contradicting intended architecture.
 **Learning:** Fragile string matching for security enforcement often creates false positives that break functionality, especially when robust parsing tools (`new URL()`) and helper utilities (`isLocalNetwork`) are already available and intended for use in the same block.
 **Prevention:** Consolidate security checks using standard URL parsers rather than redundant string prefixes. Ensure security logic aligns with intended architectural exceptions (like local network bypasses).
+## 2024-05-17 - Missing File Size Validation in Tauri APIs
+**Vulnerability:** Client-side DoS and memory exhaustion due to missing size limits on file imports using Tauri's `readTextFile`.
+**Learning:** Unlike browser `<input type="file">` which exposes `file.size`, native Tauri file dialogs only return paths. Developers must explicitly call `stat` to check sizes before reading large files.
+**Prevention:** Always pair Tauri `readTextFile` or `readFile` with a `stat` size check.

--- a/src/lib/templateImport.ts
+++ b/src/lib/templateImport.ts
@@ -101,6 +101,11 @@ export async function readTemplateTauri(): Promise<TemplateExport | null> {
 
         if (!filePath) return null; // User cancelled
 
+        const fileStat = await fsModule.stat(filePath as string);
+        if (fileStat.size > 5 * 1024 * 1024) {
+            throw new Error('File exceeds the 5MB size limit');
+        }
+
         const content = await fsModule.readTextFile(filePath as string);
         return JSON.parse(content) as TemplateExport;
     } catch (e: any) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing file size validation when importing templates via Tauri's `readTextFile` API allows maliciously large files to cause client-side DoS and memory exhaustion.
🎯 Impact: An attacker or user could load an extremely large JSON file (e.g., 2GB) and crash the application because `readTextFile` attempts to read the entire file contents into memory at once without checking its size first.
🔧 Fix: Added a `stat` size check before reading the file to ensure the file is under 5MB, matching the existing browser implementation.
✅ Verification: Ran `pnpm test` and `pnpm run build`. Note: existing CI failures are out-of-scope for this security fix. Checked that `fileStat.size` properly rejects files over the 5MB limit.

---
*PR created automatically by Jules for task [16224893068362813148](https://jules.google.com/task/16224893068362813148) started by @njtan142*