### PR TITLE
🎨 Palette: Add ARIA expanded and pressed attributes to AppShell toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-05-18 - ARIA Expanded and Pressed for AppShell Toggles
+**Learning:** Icon-only view-switcher buttons and panel toggles in the main AppShell lack `aria-expanded` and `aria-pressed` attributes. This prevents screen reader users from understanding the current state of panels (left sidebar, right inspector) or view modes (table vs grid, dark vs light).
+**Action:** Consistently apply `aria-expanded` to buttons that toggle visibility of panels, and `aria-pressed` to buttons that toggle between two distinct states (like view modes or themes).

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 **What:** Added `aria-expanded` and `aria-pressed` attributes to the icon-only toggle buttons in `AppShell.tsx` (Left Sidebar toggle, Dashboard View Mode toggle, Theme toggle, and Right Inspector toggle).
🎯 **Why:** To improve accessibility for screen reader users by explicitly communicating the current expanded/collapsed state of sidebars and the active state of view modes and themes.
📸 **Before/After:** Not a visual change.
♿ **Accessibility:** Screen readers will now announce whether the sidebars are currently expanded or collapsed, and whether the grid view or dark theme is currently pressed (active).

---
*PR created automatically by Jules for task [16056732270365896048](https://jules.google.com/task/16056732270365896048) started by @njtan142*