### PR TITLE
⚡ Bolt: Hoist state and memoize schema lookup in BackLinksPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-05-24 - Hoisting Subscriptions and Memoizing Arrays
+**Learning:** When rendering a list where each item independently subscribes to a global state store (e.g., `useLedgerStore()`) and performs O(N) lookups on shared arrays (e.g., `schemas.find()`), it causes O(L*N) complexity and excessive re-renders.
+**Action:** Hoist store subscriptions and route parameters to the parent list component. Memoize the shared array into a `Map` using `useMemo` in the parent and pass the map (or pre-computed data) down via props to the children to reduce complexity to O(L+N) and minimize re-renders.

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { useLedgerStore } from '../../stores/useLedgerStore';
 import { useProfileStore } from '../../stores/useProfileStore';
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 
 interface BackLinksPanelProps {
     targetEntryId: string;
-    targetLedgerId: string;
+    targetLedgerId?: string;
 }
 
 /**
@@ -18,10 +18,10 @@ interface BackLinksPanelProps {
  */
 export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     targetEntryId,
-    targetLedgerId,
 }) => {
-    const { backLinks, fetchBackLinks } = useLedgerStore();
+    const { backLinks, fetchBackLinks, schemas } = useLedgerStore();
     const { activeProfileId } = useProfileStore();
+    const { profileId } = useParams<{ profileId: string }>();
 
     useEffect(() => {
         if (activeProfileId && targetEntryId) {
@@ -34,6 +34,19 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     if (entries.length === 0) {
         return null;
     }
+
+    const schemaMap = useMemo(() => {
+        const map = new Map();
+        schemas.forEach(s => {
+            map.set(s._id, {
+                schema: s,
+                relationFields: s.fields?.filter(f => f.type === 'relation').map(f => f.name) || []
+            });
+        });
+        return map;
+    }, [schemas]);
+
+    const navProfileId = profileId || activeProfileId || undefined;
 
     return (
         <div className="mt-4 border-t border-zinc-200 dark:border-zinc-800 pt-4">
@@ -49,7 +62,8 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
                         key={entry._id}
                         entry={entry}
                         targetEntryId={targetEntryId}
-                        targetLedgerId={targetLedgerId}
+                        schemaInfo={schemaMap.get(entry.schemaId)}
+                        navProfileId={navProfileId}
                     />
                 ))}
             </div>
@@ -60,34 +74,32 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
 interface BackLinkItemProps {
     entry: LedgerEntry;
     targetEntryId: string;
-    targetLedgerId: string;
+    schemaInfo?: { schema: any; relationFields: string[] };
+    navProfileId?: string;
 }
 
-const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => {
-    const { schemas } = useLedgerStore();
-    const { profileId } = useParams<{ profileId: string }>();
-    const { activeProfileId } = useProfileStore();
-
-    // Find the schema for this entry's ledger
-    const entrySchema = schemas.find(s => s._id === entry.schemaId);
+const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId, schemaInfo, navProfileId }) => {
+    const entrySchema = schemaInfo?.schema;
     const ledgerName = entrySchema?.name || entry.ledgerId;
 
     // Find which fields in this entry reference the target
     const referencingFields: { fieldName: string; value: string | string[] }[] = [];
+
+    // We intentionally iterate over all Object.entries(entry.data) as in the original
+    // functionality instead of just relation fields to ensure no back-links are missed
+    // if relations are stored dynamically or in non-explicit relation fields.
     for (const [fieldName, value] of Object.entries(entry.data)) {
         if (Array.isArray(value) && value.includes(targetEntryId)) {
             referencingFields.push({ fieldName, value });
         } else if (value === targetEntryId) {
-            referencingFields.push({ fieldName, value: [value] });
+            referencingFields.push({ fieldName, value: [value as string] });
         }
     }
 
     // Get display value (first field value or entry ID)
-    const displayValue = entrySchema?.fields.length
+    const displayValue = entrySchema?.fields?.length
         ? String(entry.data[entrySchema.fields[0].name] || entry._id)
         : entry._id;
-
-    const navProfileId = profileId || activeProfileId;
 
     return (
         <Card className="p-3 bg-gray-100 dark:bg-zinc-800/30 rounded border border-zinc-300 dark:border-zinc-700 hover:border-zinc-600 transition-colors">


### PR DESCRIPTION
💡 What: Hoisted hooks (`useLedgerStore`, `useProfileStore`, `useParams`) and schema mapping out of `BackLinkItem` into its parent `BackLinksPanel`. Passed memoized `schemaInfo` via props.

🎯 Why: Previously, every `BackLinkItem` independently subscribed to global stores and searched through the entire `schemas` array, causing O(L*N) lookups and excessive re-renders for large lists.

📊 Impact: Significantly reduces React re-renders and memory overhead by avoiding individual store subscriptions per item. Lookup complexity reduced from O(L*N) to O(L+N).

🔬 Measurement: Observe memory usage and rendering time via React Profiler when viewing a ledger entry with many back-links. Run `pnpm test tests/BackLinksPanel.test.tsx` and `pnpm build` to verify correctness.

---
*PR created automatically by Jules for task [18429206528433528951](https://jules.google.com/task/18429206528433528951) started by @njtan142*