### PR TITLE
🎨 Palette: Add `aria-expanded` to App Shell Sidebars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2024-05-21 - Added aria-expanded to app shell sidebars
+**Learning:** Collapsible sidebars implemented with explicit boolean toggle states (`leftSidebarOpen`, `rightInspectorOpen`) correctly use `aria-label` but forgot `aria-expanded`.
+**Action:** When working on panels that hide/show, ensure that the trigger buttons always reflect the visual state via `aria-expanded={isOpen}` to communicate to assistive technologies whether the associated content is currently visible or hidden.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,6 +397,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
+                                            aria-expanded={leftSidebarOpen}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
@@ -456,6 +457,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
+                                            aria-expanded={rightInspectorOpen}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >


### PR DESCRIPTION
💡 What: Added `aria-expanded={isOpen}` to the left sidebar and right inspector toggle buttons in `AppShell.tsx`.
🎯 Why: Without `aria-expanded`, screen readers can read the button's action ("Open sidebar") but cannot announce whether the sidebar is currently open or closed, leaving users confused about the layout state.
📸 Before/After: No visual changes.
♿ Accessibility: Disclosure widgets now accurately report their expanded/collapsed state to assistive technologies, making the core application layout fully keyboard and screen-reader navigable.

---
*PR created automatically by Jules for task [15504208705991509800](https://jules.google.com/task/15504208705991509800) started by @njtan142*