### PR TITLE
🎨 Palette: Improve accessibility of layout toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-24 - Semantic ARIA attributes on state-controlling Toggles
+**Learning:** Adding both `aria-pressed` and `aria-expanded` to a single button is generally an ARIA anti-pattern. If a button simply toggles a state without showing/hiding new UI structure (like a View Mode table/grid switch or a Theme switch), it should use `aria-pressed`. If a button explicitly controls the visibility of another structural section (like an expandable sidebar or inspector panel), it should use `aria-expanded` to reflect the expanded/collapsed state of that region.
+**Action:** Always map the appropriate ARIA attribute to the correct interactive behavior: `aria-pressed` for independent toggle states, and `aria-expanded` for buttons that control collapsible regions.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'table'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 **What:**
Added `aria-expanded` and `aria-pressed` to the icon-only toggle buttons in the main navigation toolbar (`AppShell.tsx`), including the left sidebar, right inspector, theme mode, and dashboard view mode toggles.

🎯 **Why:**
Screen reader users relying on keyboard navigation had no semantic cues indicating whether the sidebars/panels were currently open or closed, or whether they were using light/dark mode or table/grid views. Adding proper ARIA state attributes makes the UI state changes explicitly accessible.

📸 **Before/After:**
*(Internal, semantic HTML change — no visual impact)*

♿ **Accessibility:**
Added `aria-expanded` attributes to buttons controlling collapsible regions (Sidebars and Inspectors) and added `aria-pressed` for explicit toggle states (Dark Mode and View Mode switches) so assistive technologies accurately report their status.

---
*PR created automatically by Jules for task [1428191390812550263](https://jules.google.com/task/1428191390812550263) started by @njtan142*