### PR TITLE
🎨 Palette: Add ARIA expanded and pressed states to AppShell toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-05-26 - Dynamic aria-expanded for Layout Toggles
+**Learning:** While `aria-pressed` is crucial for simple state toggles, buttons that control the visibility of substantial UI sections (like sidebars and inspector panels) should also clearly signal whether those sections are currently shown.
+**Action:** For layout toggle buttons that expand or collapse sections, explicitly add and dynamically bind the `aria-expanded` attribute to the boolean visibility state of the target panel (e.g., `aria-expanded={isOpen}`) to communicate the expanded/collapsed state to screen readers.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,6 +397,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
+                                            aria-expanded={leftSidebarOpen}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
@@ -422,6 +423,7 @@ export const AppShell: React.FC = () => {
                                                 variant="outline"
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
+                                                aria-pressed={dashboardViewMode === 'table'}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
@@ -439,6 +441,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleTheme}
+                                            aria-pressed={theme === 'dark'}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
@@ -456,6 +459,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
+                                            aria-expanded={rightInspectorOpen}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-pressed` attributes to toggle buttons in the AppShell header.
🎯 Why: Icon-only state-switching buttons often miss explicitly conveying their active state or the state of their associated panel. This makes the UI more accessible for screen reader users by properly conveying the expanded state of sidebars and the active state of view modes and themes.
📸 Before/After: Visuals remain unchanged, but assistive technologies will now correctly announce states.
♿ Accessibility: Improves screen reader compatibility for critical navigation and view switchers.

---
*PR created automatically by Jules for task [12173716148418312980](https://jules.google.com/task/12173716148418312980) started by @njtan142*