### PR TITLE
🎨 Palette: Add aria-expanded to layout toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-30 - Layout Toggle Accessibility
+**Learning:** For layout toggle buttons that expand or collapse sections (such as sidebars or inspector panels), dynamically binding the `aria-expanded` attribute to the boolean visibility state of the target panel is important to ensure the state is correctly communicated to screen readers.
+**Action:** Always add an `aria-expanded` attribute reflecting the expanded/collapsed state on layout toggles (e.g. sidebars or panels).

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,6 +397,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
+                                            aria-expanded={leftSidebarOpen}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
@@ -456,6 +457,7 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
+                                            aria-expanded={rightInspectorOpen}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >


### PR DESCRIPTION
💡 What: Added `aria-expanded` attributes to the layout toggle buttons (sidebar and inspector) in `AppShell`.
🎯 Why: Icon-only layout toggles that expand or collapse sections need to communicate their state dynamically to screen readers so users know whether a panel is currently open or closed.
📸 Before/After: Structural HTML change only, no visual difference.
♿ Accessibility: Improves screen reader accessibility by providing state awareness (`aria-expanded="true/false"`) rather than just a static `aria-label`.

---
*PR created automatically by Jules for task [16937679339284976880](https://jules.google.com/task/16937679339284976880) started by @njtan142*