### PR TITLE
⚡ Bolt: Optimize node lookups in validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-05-28 - Optimize nodes.find() in validation loop
+**Learning:** Using `nodes.find()` repeatedly inside `.forEach()` and `.filter()` in validation loops creates an O(N^2) bottleneck for large graph validations.
+**Action:** Pre-compute a `Map` of nodes by ID (`nodesById = new Map(nodes.map(n => [n.id, n]))`) before the loop to reduce lookup complexity to O(1) and improve overall time complexity to O(N).

--- a/src/features/nodeEditor/utils/validateContainerIntegrity.ts
+++ b/src/features/nodeEditor/utils/validateContainerIntegrity.ts
@@ -25,10 +25,12 @@ export const validateContainerIntegrity = (
     const errors: string[] = [];
     let repaired = [...nodes];
     
+    const nodesById = new Map(nodes.map(n => [n.id, n]));
+
     // 1. Check for orphaned children (React Flow v12 uses parentId)
     repaired.forEach((node, index) => {
         if (node.parentId) {
-            const parent = nodes.find(n => n.id === node.parentId);
+            const parent = nodesById.get(node.parentId);
             if (!parent) {
                 errors.push(`Orphaned child: ${node.id} references missing parent ${node.parentId}`);
                 // Auto-repair: clear parentId
@@ -44,7 +46,7 @@ export const validateContainerIntegrity = (
             const rawChildIds = node.data.childNodeIds;
             const childNodeIds: string[] = Array.isArray(rawChildIds) ? rawChildIds : [];
             const missingChildren = childNodeIds.filter(
-                childId => !nodes.find(n => n.id === childId)
+                childId => !nodesById.has(childId)
             );
             
             if (missingChildren.length > 0) {
@@ -62,13 +64,19 @@ export const validateContainerIntegrity = (
             }
             
             // Check that all children actually reference this container (using parentId)
-            const children = nodes.filter(n => childNodeIds.includes(n.id));
-            const misparentedChildren = children.filter(n => n.parentId !== node.id);
+            const misparentedChildren = [];
+            for (const childId of childNodeIds) {
+                const childNode = nodesById.get(childId);
+                if (childNode && childNode.parentId !== node.id) {
+                    misparentedChildren.push(childNode);
+                }
+            }
             if (misparentedChildren.length > 0) {
                 errors.push(`Container ${node.id} has children with wrong parentId: ${misparentedChildren.map(n => n.id).join(', ')}`);
                 // Auto-repair: fix parentId on children
+                const misparentedSet = new Set(misparentedChildren.map(n => n.id));
                 repaired = repaired.map(n => {
-                    if (misparentedChildren.find(c => c.id === n.id)) {
+                    if (misparentedSet.has(n.id)) {
                         return { ...n, parentId: node.id, extent: 'parent' as const };
                     }
                     return n;
@@ -78,10 +86,11 @@ export const validateContainerIntegrity = (
     });
     
     // 3. Prevent circular references
+    const repairedById = new Map(repaired.map(n => [n.id, n]));
     const hasCircularRef = (nodeId: string, visited = new Set<string>()): boolean => {
         if (visited.has(nodeId)) return true;
         visited.add(nodeId);
-        const node = repaired.find(n => n.id === nodeId);
+        const node = repairedById.get(nodeId);
         if (node?.parentId) {
             return hasCircularRef(node.parentId, visited);
         }
@@ -95,7 +104,9 @@ export const validateContainerIntegrity = (
             const index = repaired.findIndex(n => n.id === node.id);
             if (index !== -1) {
                 const { parentId: _, extent: __, ...rest } = node;
-                repaired[index] = rest as Node;
+                const repairedNode = rest as Node;
+                repaired[index] = repairedNode;
+                repairedById.set(node.id, repairedNode); // Update cache
             }
         }
     });
@@ -113,7 +124,10 @@ export const validateContainerIntegrity = (
                         type: 'container',
                         label: 'Group',
                         isCollapsed: false,
-                        childNodeIds: nodes.filter(n => n.parentId === node.id).map(n => n.id),
+                        childNodeIds: nodes.reduce<string[]>((acc, n) => {
+                            if (n.parentId === node.id) acc.push(n.id);
+                            return acc;
+                        }, []),
                         createdAt: new Date().toISOString(),
                     },
                 };


### PR DESCRIPTION
💡 What: Replaced O(N²) array `.find()` lookups with O(1) `Map` lookups and removed chained `.filter().map()` calls in `validateContainerIntegrity.ts`.
🎯 Why: To prevent main thread blocking and jank when validating layouts with thousands of nodes, and reduce memory overhead from intermediate array allocations.
📊 Impact: Changes O(N²) complexity to O(N), significantly speeding up the validation loop on large node graphs.
🔬 Measurement: Observe lower CPU usage and faster layout validation times in DevTools profiler for graphs >1000 nodes.

---
*PR created automatically by Jules for task [3751266099701041298](https://jules.google.com/task/3751266099701041298) started by @njtan142*