### PR TITLE
⚡ Bolt: Replace Math.min/max and map/filter chains with single-pass loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2024-05-28 - Avoid Array Spread with Math.min/max for large arrays
+**Learning:** Using `Math.min(...values)` or `Math.max(...values)` with large arrays can throw a `RangeError: Maximum call stack size exceeded` because the spread operator effectively passes each element as a separate argument to the function, and JS engines have limits on the number of arguments a function can accept.
+**Action:** When calculating min/max over potentially large data sets (like ledger entries), always use a single-pass `for` loop to track min/max manually. This completely avoids the call stack exception and is also significantly faster.

--- a/src/features/nodeEditor/hooks/useLedgerData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerData.ts
@@ -90,20 +90,34 @@ export async function hydrateLedgerSourceNode(
 
     if (numberFields.length > 0 && filteredEntries.length > 0) {
       numberFields.forEach(field => {
-        const values = filteredEntries
-          .map(e => e.data[field.id])
-          .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        // Bolt Performance Optimization:
+        // Single-pass loop prevents intermediate array allocations (O(N) instead of O(N*3)).
+        // Avoids Math.min/max spread syntax which causes call stack exceptions on large ledgers.
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
 
-        if (values.length > 0) {
+        for (let i = 0; i < filteredEntries.length; i++) {
+          const val = filteredEntries[i].data[field.id];
+          if (typeof val === 'number' && !isNaN(val)) {
+            sum += val;
+            if (val < min) min = val;
+            if (val > max) max = val;
+            count++;
+          }
+        }
+
+        if (count > 0) {
           aggregates.sum = aggregates.sum || {};
           aggregates.avg = aggregates.avg || {};
           aggregates.min = aggregates.min || {};
           aggregates.max = aggregates.max || {};
 
-          aggregates.sum[field.id] = values.reduce((a, b) => a + b, 0);
-          aggregates.avg[field.id] = aggregates.sum[field.id] / values.length;
-          aggregates.min[field.id] = Math.min(...values);
-          aggregates.max[field.id] = Math.max(...values);
+          aggregates.sum[field.id] = sum;
+          aggregates.avg[field.id] = sum / count;
+          aggregates.min[field.id] = min;
+          aggregates.max[field.id] = max;
         }
       });
     }

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,32 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            // Bolt Performance Optimization:
+            // Single-pass loop prevents intermediate array allocations (O(N) instead of O(N*3)).
+            // Avoids Math.min/max spread syntax which causes call stack exceptions on large ledgers.
+            let sum = 0;
+            let min = Infinity;
+            let max = -Infinity;
+            let count = 0;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const val = entries[i].data[fieldId];
+                if (typeof val === 'number' && !isNaN(val)) {
+                    sum += val;
+                    if (val < min) min = val;
+                    if (val > max) max = val;
+                    count++;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min,
+                    max,
+                    count,
                 };
             }
         });
@@ -201,17 +215,31 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        // Bolt Performance Optimization:
+        // Single-pass loop prevents intermediate array allocations (O(N) instead of O(N*3)).
+        // Avoids Math.min/max spread syntax which causes call stack exceptions on large ledgers.
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
+
+        for (let i = 0; i < entries.length; i++) {
+            const val = entries[i].data[fieldId];
+            if (typeof val === 'number' && !isNaN(val)) {
+                sum += val;
+                if (val < min) min = val;
+                if (val > max) max = val;
+                count++;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min,
+            max,
+            count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
- 💡 **What**: Replaced array spread `Math.min/max(...values)` and chained `.map().filter()` with a single-pass `for` loop in `useLedgerSourceData` and `useLedgerData`.
- 🎯 **Why**: Avoids `Maximum call stack size exceeded` errors on large datasets and prevents redundant iterations and intermediate object allocations.
- 📊 **Impact**: Improves CPU time and memory usage from O(N*3) multiple passes to an O(N) single pass, mitigating call stack size exceptions for large ledgers.
- 🔬 **Measurement**: Observe large dataset rendering times and confirm no stack overflows occur on ledgers with tens of thousands of rows.

---
*PR created automatically by Jules for task [10683426697776651340](https://jules.google.com/task/10683426697776651340) started by @njtan142*