### PR TITLE
⚡ Bolt: Optimize BackLinkItem list rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-06-07 - Elevate store subscriptions out of list items
+**Learning:** When rendering lists of child components (e.g., `BackLinkItem`), having each child independently subscribe to a global state store (like `useLedgerStore()`) creates an individual subscription per item. This leads to massive numbers of unnecessary re-renders and memory overhead when the list is large.
+**Action:** Always fetch the required data (e.g., `schemas`, route parameters) in the parent component and pass it down as props to the list items, preventing O(N) store subscriptions.

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { useLedgerStore } from '../../stores/useLedgerStore';
 import { useProfileStore } from '../../stores/useProfileStore';
-import { LedgerEntry } from '../../types/ledger';
+import { LedgerEntry, LedgerSchema } from '../../types/ledger';
 import { Link, useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
@@ -23,7 +23,7 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     const { backLinks, fetchBackLinks, schemas } = useLedgerStore();
     const { profileId } = useParams<{ profileId: string }>();
     const { activeProfileId } = useProfileStore();
-    const navProfileId = profileId || activeProfileId;
+    const navProfileId = profileId || activeProfileId || undefined;
 
     useEffect(() => {
         if (activeProfileId && targetEntryId) {
@@ -60,8 +60,6 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
         </div>
     );
 };
-
-import { LedgerSchema } from '../../types/ledger';
 
 interface BackLinkItemProps {
     entry: LedgerEntry;

--- a/src/features/ledger/BackLinksPanel.tsx
+++ b/src/features/ledger/BackLinksPanel.tsx
@@ -20,8 +20,10 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     targetEntryId,
     targetLedgerId,
 }) => {
-    const { backLinks, fetchBackLinks } = useLedgerStore();
+    const { backLinks, fetchBackLinks, schemas } = useLedgerStore();
+    const { profileId } = useParams<{ profileId: string }>();
     const { activeProfileId } = useProfileStore();
+    const navProfileId = profileId || activeProfileId;
 
     useEffect(() => {
         if (activeProfileId && targetEntryId) {
@@ -50,6 +52,8 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
                         entry={entry}
                         targetEntryId={targetEntryId}
                         targetLedgerId={targetLedgerId}
+                        schemas={schemas}
+                        navProfileId={navProfileId}
                     />
                 ))}
             </div>
@@ -57,17 +61,17 @@ export const BackLinksPanel: React.FC<BackLinksPanelProps> = ({
     );
 };
 
+import { LedgerSchema } from '../../types/ledger';
+
 interface BackLinkItemProps {
     entry: LedgerEntry;
     targetEntryId: string;
     targetLedgerId: string;
+    schemas: LedgerSchema[];
+    navProfileId: string | undefined;
 }
 
-const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => {
-    const { schemas } = useLedgerStore();
-    const { profileId } = useParams<{ profileId: string }>();
-    const { activeProfileId } = useProfileStore();
-
+const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId, schemas, navProfileId }) => {
     // Find the schema for this entry's ledger
     const entrySchema = schemas.find(s => s._id === entry.schemaId);
     const ledgerName = entrySchema?.name || entry.ledgerId;
@@ -86,8 +90,6 @@ const BackLinkItem: React.FC<BackLinkItemProps> = ({ entry, targetEntryId }) => 
     const displayValue = entrySchema?.fields.length
         ? String(entry.data[entrySchema.fields[0].name] || entry._id)
         : entry._id;
-
-    const navProfileId = profileId || activeProfileId;
 
     return (
         <Card className="p-3 bg-gray-100 dark:bg-zinc-800/30 rounded border border-zinc-300 dark:border-zinc-700 hover:border-zinc-600 transition-colors">


### PR DESCRIPTION
💡 **What:** Hoist store subscriptions and route parameter hooks out of the `BackLinkItem` component up to its parent `BackLinksPanel`, passing the necessary state down as props.
🎯 **Why:** When rendering large lists, having each child component independently subscribe to a global Zustand store (e.g., `useLedgerStore`) or context creates an individual subscription for every item. This leads to severe memory overhead and massive numbers of unnecessary re-renders across the list whenever the global state changes.
📊 **Impact:** Reduces store subscriptions from O(N) to O(1) for the BackLinks list, preventing performance degradation and main-thread blocking when rendering many backlinks.
🔬 **Measurement:** Use React DevTools Profiler while viewing an entry with multiple backlinks to observe that `BackLinkItem` no longer subscribes directly to the store and only re-renders when its specific props change.

---
*PR created automatically by Jules for task [1799622295886202837](https://jules.google.com/task/1799622295886202837) started by @njtan142*