### PR TITLE
🎨 Palette: Add dynamic aria-expanded to layout toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-02-23 - Dynamic `aria-expanded` for Layout Toggles
+**Learning:** Hardcoded `aria-expanded` attributes (e.g., `aria-expanded="false"`) or completely missing `aria-expanded` attributes on layout toggles (like sidebars and inspector rails) prevent screen reader users from knowing whether the associated panel is currently open or closed.
+**Action:** Always bind the `aria-expanded` attribute to the boolean state variable controlling the panel's visibility (e.g., `aria-expanded={isOpen}`) to dynamically announce state changes.

--- a/src/features/shell/InspectorRail.tsx
+++ b/src/features/shell/InspectorRail.tsx
@@ -30,6 +30,7 @@ export const InspectorRail = () => {
                     size="icon-xs"
                     className="text-zinc-400"
                     aria-label="Collapse inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronRight className="w-4 h-4" />
                 </Button>
@@ -64,6 +65,7 @@ export const InspectorRail = () => {
                     size="icon-sm"
                     className="rounded-full bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md text-zinc-400"
                     aria-label="Expand inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar = () => {
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Collapse sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -63,7 +64,7 @@ export const Sidebar = () => {
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
                     aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -103,6 +104,7 @@ export const Sidebar = () => {
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
                     aria-label="Expand sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>


### PR DESCRIPTION
**💡 What:**
Added dynamic `aria-expanded` attributes to all expand/collapse toggle buttons within the layout shell components (`Sidebar` and `InspectorRail`). The attributes are now bound to the respective boolean state variables (`sidebarOpen` and `inspectorOpen`). Furthermore, a hardcoded `aria-expanded="false"` bug on the mobile hamburger menu was fixed to properly reflect its true state.

**🎯 Why:**
Toggle buttons that control the visibility of large layout panels (like sidebars and inspectors) must announce their current state to screen reader users. Without a dynamic `aria-expanded` attribute, non-sighted users have no contextual way of knowing if activating the button successfully opened or closed the panel, leading to confusion and poor navigation.

**📸 Before/After:**
*(Visuals remain unchanged. Structural accessibility improvement only).*
*Before:* `<Button aria-label="Expand sidebar" />`
*After:* `<Button aria-label="Expand sidebar" aria-expanded={sidebarOpen} />`

**♿ Accessibility:**
- Ensures compliance with WAI-ARIA authoring practices for disclosure (show/hide) widgets.
- Provides immediate, accurate feedback to assistive technologies when layout states change.

---
*PR created automatically by Jules for task [1506594507394147829](https://jules.google.com/task/1506594507394147829) started by @njtan142*