### PR TITLE
🎨 Palette: Add ARIA state attributes to Layout toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-19 - Layout State Toggles ARIA Attributes
+**Learning:** For layout toggle buttons that expand or collapse sections (sidebars, inspector panels), and for state toggle buttons (theme, view mode) that use icons only, adding `aria-expanded` and `aria-pressed` respectively is critical to ensuring the state is correctly communicated to screen readers.
+**Action:** Always add an `aria-expanded={isOpen}` boolean attribute alongside an `aria-label` for any toggleable or state-switching icon buttons that control visibility of panels, and `aria-pressed={isActive}` for buttons acting as toggles for state.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'table'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-pressed` to Layout toggle buttons in `src/components/Layout/AppShell.tsx`.
🎯 Why: To convey the active state of icon-only layout/state toggle buttons to screen reader users, preventing them from only relying on visual cues. 
📸 Before/After: Visuals unaffected.
♿ Accessibility: Ensures the structural "sidebar open" and "theme state" icon-only buttons accurately communicate state using standard ARIA boolean properties.

---
*PR created automatically by Jules for task [792565821026391303](https://jules.google.com/task/792565821026391303) started by @njtan142*