### PR TITLE
⚡ Bolt: Optimize array aggregations to prevent call stack limits

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2025-01-20 - Prevent call stack errors on large array aggregations
+**Learning:** Using chained array iteration methods like `.map().filter()` combined with spread operators like `Math.max(...values)` causes O(N) auxiliary memory usage and pushes elements to the call stack. For massive datasets, this leads to `RangeError: Maximum call stack size exceeded`.
+**Action:** Replace multi-pass iteration and spread functions with a single-pass accumulator `for` loop to dramatically reduce memory footprint and avoid call stack limits.

--- a/src/features/nodeEditor/hooks/useLedgerData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerData.ts
@@ -90,20 +90,31 @@ export async function hydrateLedgerSourceNode(
 
     if (numberFields.length > 0 && filteredEntries.length > 0) {
       numberFields.forEach(field => {
-        const values = filteredEntries
-          .map(e => e.data[field.id])
-          .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let sum = 0;
+        let count = 0;
+        let min = Infinity;
+        let max = -Infinity;
 
-        if (values.length > 0) {
+        for (let i = 0; i < filteredEntries.length; i++) {
+          const v = filteredEntries[i].data[field.id];
+          if (typeof v === 'number' && !isNaN(v)) {
+            sum += v;
+            count++;
+            if (v < min) min = v;
+            if (v > max) max = v;
+          }
+        }
+
+        if (count > 0) {
           aggregates.sum = aggregates.sum || {};
           aggregates.avg = aggregates.avg || {};
           aggregates.min = aggregates.min || {};
           aggregates.max = aggregates.max || {};
 
-          aggregates.sum[field.id] = values.reduce((a, b) => a + b, 0);
-          aggregates.avg[field.id] = aggregates.sum[field.id] / values.length;
-          aggregates.min[field.id] = Math.min(...values);
-          aggregates.max[field.id] = Math.max(...values);
+          aggregates.sum[field.id] = sum;
+          aggregates.avg[field.id] = sum / count;
+          aggregates.min[field.id] = min;
+          aggregates.max[field.id] = max;
         }
       });
     }

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,29 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            let sum = 0;
+            let count = 0;
+            let min = Infinity;
+            let max = -Infinity;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const v = entries[i].data[fieldId];
+                if (typeof v === 'number' && !isNaN(v)) {
+                    sum += v;
+                    count++;
+                    if (v < min) min = v;
+                    if (v > max) max = v;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min: min,
+                    max: max,
+                    count: count,
                 };
             }
         });
@@ -201,17 +212,28 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let sum = 0;
+        let count = 0;
+        let min = Infinity;
+        let max = -Infinity;
+
+        for (let i = 0; i < entries.length; i++) {
+            const v = entries[i].data[fieldId];
+            if (typeof v === 'number' && !isNaN(v)) {
+                sum += v;
+                count++;
+                if (v < min) min = v;
+                if (v > max) max = v;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min: min,
+            max: max,
+            count: count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
💡 What: Replaced chained `.map().filter()` and spread operators (`Math.max(...values)`) with a single-pass `for` loop in `useLedgerData` and `useLedgerSourceData`.
🎯 Why: Chained array methods and spread operators cause O(N) intermediate allocations and push elements to the call stack, leading to `RangeError: Maximum call stack size exceeded` on massive datasets.
📊 Impact: Eliminates call stack size errors, reduces auxiliary memory footprint from O(N) to O(1), and prevents redundant iterations.
🔬 Measurement: Verify with large ledger datasets (> 100,000 entries). The "Maximum call stack size exceeded" error will no longer occur when displaying node source data stats, and CPU/memory usage during computation will be noticeably reduced.

---
*PR created automatically by Jules for task [1525481530309611601](https://jules.google.com/task/1525481530309611601) started by @njtan142*