### PR TITLE
🎨 Palette: Replace dynamic aria-labels with static labels + aria-pressed/expanded on AppShell toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-02-23 - Static ARIA Labels for Toggle Buttons
+**Learning:** Dynamic aria-labels on toggle buttons (e.g. "Open sidebar" -> "Close sidebar") confuse screen readers when state changes. Tooltip text should match the static aria-label exactly.
+**Action:** Always use static aria-labels (e.g. "Toggle left sidebar") paired with explicit state attributes (aria-expanded or aria-pressed) for toggle buttons, and match the tooltip text to the aria-label.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,14 +397,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
-                                            aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-label="Toggle left sidebar"
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}</p>
+                                        <p>Toggle left sidebar</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -49,7 +49,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
-                    aria-label="Collapse sidebar"
+                    aria-label="Toggle left sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -62,8 +63,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
-                    aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-label="Toggle left sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -102,7 +103,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
-                    aria-label="Expand sidebar"
+                    aria-label="Toggle left sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>

--- a/tests/AppShell.test.tsx
+++ b/tests/AppShell.test.tsx
@@ -124,7 +124,7 @@ describe("AppShell Component", () => {
         // Resolve ambiguity by checking for the header title specifically
         expect(screen.getByRole('heading', { name: /Ledger: Test Profile/i })).toBeInTheDocument();
         expect(screen.getByText('Inspector')).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /close sidebar/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /toggle left sidebar/i })).toBeInTheDocument();
     });
 
     it("performs initial responsive check on mount", () => {
@@ -169,7 +169,7 @@ describe("AppShell Component", () => {
             </MemoryRouter>
         );
 
-        const toggleBtn = screen.getByRole('button', { name: /close sidebar/i });
+        const toggleBtn = screen.getByRole('button', { name: /toggle left sidebar/i });
         fireEvent.click(toggleBtn);
         expect(mockUIState.toggleLeftSidebar).toHaveBeenCalled();
     });


### PR DESCRIPTION
💡 What: Replaced dynamic `aria-label`s on header and sidebar toggle buttons with static labels and `aria-expanded`/`aria-pressed` attributes.
🎯 Why: Dynamic labels that change text confuse screen readers and lead to brittle tests. Static labels with explicit state attributes clearly communicate the control's purpose and its current state.
📸 Before/After: N/A (Non-visual structural change)
♿ Accessibility: Improved screen reader support by binding state attributes explicitly and standardizing ARIA labels.

---
*PR created automatically by Jules for task [15500278624949279758](https://jules.google.com/task/15500278624949279758) started by @njtan142*