### PR TITLE
⚡ Bolt: Replace Math.max/min spread with single-pass loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2025-05-18 - Avoid Math.min/max spread for large arrays
+**Learning:** Using spread syntax (`Math.max(...array)`) on large arrays pushes elements to the call stack causing `RangeError: Maximum call stack size exceeded`. Also, chaining `reduce`, `Math.min`, and `Math.max` loops array multiple times.
+**Action:** Use a single-pass `for` loop to compute sum, min, and max simultaneously. It avoids call stack limits and performs O(1) loop iteration instead of O(N) operations.

--- a/src/features/nodeEditor/hooks/useLedgerData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerData.ts
@@ -100,10 +100,20 @@ export async function hydrateLedgerSourceNode(
           aggregates.min = aggregates.min || {};
           aggregates.max = aggregates.max || {};
 
-          aggregates.sum[field.id] = values.reduce((a, b) => a + b, 0);
-          aggregates.avg[field.id] = aggregates.sum[field.id] / values.length;
-          aggregates.min[field.id] = Math.min(...values);
-          aggregates.max[field.id] = Math.max(...values);
+          let sum = 0;
+          let min = Infinity;
+          let max = -Infinity;
+          for (let i = 0; i < values.length; i++) {
+              const val = values[i];
+              sum += val;
+              if (val < min) min = val;
+              if (val > max) max = val;
+          }
+
+          aggregates.sum[field.id] = sum;
+          aggregates.avg[field.id] = sum / values.length;
+          aggregates.min[field.id] = min;
+          aggregates.max[field.id] = max;
         }
       });
     }

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -61,10 +61,20 @@ export const useLedgerSourceData = (
             if (values.length === 0) {
                 result[fieldId] = null;
             } else {
+                let sum = 0;
+                let min = Infinity;
+                let max = -Infinity;
+                for (let i = 0; i < values.length; i++) {
+                    const val = values[i];
+                    sum += val;
+                    if (val < min) min = val;
+                    if (val > max) max = val;
+                }
+
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
+                    avg: sum / values.length,
+                    min,
+                    max,
                     count: values.length,
                 };
             }
@@ -207,10 +217,20 @@ export const useFieldStats = (
         
         if (values.length === 0) return null;
         
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        for (let i = 0; i < values.length; i++) {
+            const val = values[i];
+            sum += val;
+            if (val < min) min = val;
+            if (val > max) max = val;
+        }
+
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
+            avg: sum / values.length,
+            min,
+            max,
             count: values.length,
         };
     }, [entries, fieldId]);

--- a/src/features/nodeEditor/utils/statistics.ts
+++ b/src/features/nodeEditor/utils/statistics.ts
@@ -101,11 +101,21 @@ export const calculateArithmetic = (
         case 'average':
             return { value: values.reduce((a, b) => a + b, 0) / values.length };
 
-        case 'min':
-            return { value: Math.min(...values) };
+        case 'min': {
+            let min = Infinity;
+            for (let i = 0; i < values.length; i++) {
+                if (values[i] < min) min = values[i];
+            }
+            return { value: min };
+        }
 
-        case 'max':
-            return { value: Math.max(...values) };
+        case 'max': {
+            let max = -Infinity;
+            for (let i = 0; i < values.length; i++) {
+                if (values[i] > max) max = values[i];
+            }
+            return { value: max };
+        }
 
         default:
             return { value: null, error: 'Unknown operation' };


### PR DESCRIPTION
💡 **What**: Replaced `Math.max(...values)`, `Math.min(...values)`, and `reduce()` sequences with single-pass `for` loops in `useLedgerSourceData`, `useLedgerData`, and `statistics.ts`.
🎯 **Why**: Using the spread operator (`...values`) on large datasets pushes elements to the call stack, causing `RangeError: Maximum call stack size exceeded`. Additionally, chaining multiple array iterations loops through the data multiple times redundantly.
📊 **Impact**: Prevents application crashes on large datasets and improves execution time for statistics by performing a single pass ($O(N)$ operations) instead of three passes.
🔬 **Measurement**: Verified the logic using the test suite (`pnpm test`) for the modified features. Tested script examples confirming large arrays crash standard spread approaches and that loops run cleanly.

---
*PR created automatically by Jules for task [12049259098029083803](https://jules.google.com/task/12049259098029083803) started by @njtan142*