### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leak in sync remote URL logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** A redundant string-matching check for `https://` and `localhost` (`remoteUrl.startsWith`) was placed before a robust `URL` parsing block that correctly leveraged `isLocalNetwork`. This caused the application to mistakenly throw "HTTPS is required" errors for valid private network IPs (e.g., `192.168.x.x`), breaking self-hosted local-first sync workflows and contradicting intended architecture.
 **Learning:** Fragile string matching for security enforcement often creates false positives that break functionality, especially when robust parsing tools (`new URL()`) and helper utilities (`isLocalNetwork`) are already available and intended for use in the same block.
 **Prevention:** Consolidate security checks using standard URL parsers rather than redundant string prefixes. Ensure security logic aligns with intended architectural exceptions (like local network bypasses).
+## 2025-06-13 - Sync Credential Leak in Logs
+**Vulnerability:** The application was logging the full remote CouchDB URL, which could contain the user's plain-text password, when a connection or parsing error occurred during sync setup.
+**Learning:** Even when errors occur early in a setup process, any constructed URLs that include credentials must be sanitized before being passed to `console.error` or any logging system.
+**Prevention:** Always parse URLs and mask the `.password` field (e.g., using `url.password = '***'`) before logging them. If parsing fails, use regex or redact the string to prevent credential leakage.

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1852,7 +1852,20 @@ export function setup_sync(
             if (e.message.includes('Insecure connection')) {
                 throw e; // Rethrow security error
             }
-            console.error('Invalid remote URL:', remoteUrl);
+
+            // Sanitize URL before logging
+            let sanitizedUrl = remoteUrl;
+            try {
+                const parsedUrl = new URL(remoteUrl);
+                if (parsedUrl.password) {
+                    parsedUrl.password = '***';
+                }
+                sanitizedUrl = parsedUrl.toString();
+            } catch {
+                // If parsing fails, use regex to mask potential passwords in auth strings
+                sanitizedUrl = remoteUrl.replace(/(?:\/\/[^:]+:)([^@]+)(?=@)/, '***');
+            }
+            console.error('Invalid remote URL:', sanitizedUrl);
         }
     }
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The CouchDB remote sync setup in `src/lib/db.ts` was passing the user's `remoteUrl` to `console.error` directly when parsing logic or connection logic threw an error. This URL could contain the user's plain-text database password.
🎯 **Impact**: Credential leak to browser or application logs, which could be collected by telemetry or accessible locally.
🔧 **Fix**: Added URL sanitization in the `catch` block. The URL is parsed, and if a password is present, it's overwritten with `***` before formatting the string and logging. Included a regex fallback if the native `URL` parser fails to mask standard basic auth credentials.
✅ **Verification**: Code tested to ensure logging works and `pnpm test src/lib/db.test.ts` passes.

---
*PR created automatically by Jules for task [11234301540293049320](https://jules.google.com/task/11234301540293049320) started by @njtan142*