### PR TITLE
🎨 Palette: Make panel toggles accessible with static labels and aria-expanded

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## $(date +%Y-%m-%d) - Static Aria Labels for Toggles
+**Learning:** Using dynamic `aria-label` values (like "Open/Close") on toggles is an accessibility anti-pattern. Static `aria-label`s combined with explicit `aria-expanded` or `aria-pressed` state attributes provide a more robust experience for screen reader users.
+**Action:** Replace dynamic aria-labels with static labels (e.g. "Toggle sidebar") and bind `aria-expanded` to the visibility state of the target panel. Update matching tooltips and tests.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,14 +397,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
-                                            aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-label="Toggle sidebar"
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}</p>
+                                        <p>Toggle sidebar</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -456,14 +457,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
-                                            aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-label="Toggle inspector"
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{rightInspectorOpen ? 'Close inspector' : 'Open inspector'}</p>
+                                        <p>Toggle inspector</p>
                                     </TooltipContent>
                                 </Tooltip>
                             </div>

--- a/src/features/shell/InspectorRail.tsx
+++ b/src/features/shell/InspectorRail.tsx
@@ -29,7 +29,8 @@ export const InspectorRail = () => {
                     variant="ghost"
                     size="icon-xs"
                     className="text-zinc-400"
-                    aria-label="Collapse inspector"
+                    aria-label="Toggle inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronRight className="w-4 h-4" />
                 </Button>
@@ -63,7 +64,8 @@ export const InspectorRail = () => {
                     variant="outline"
                     size="icon-sm"
                     className="rounded-full bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md text-zinc-400"
-                    aria-label="Expand inspector"
+                    aria-label="Toggle inspector"
+                    aria-expanded={inspectorOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>

--- a/src/features/shell/Sidebar.tsx
+++ b/src/features/shell/Sidebar.tsx
@@ -49,7 +49,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon-xs"
                     className="text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-800/50"
-                    aria-label="Collapse sidebar"
+                    aria-label="Toggle sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -62,8 +63,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon"
                     className="md:hidden absolute left-2 top-2 bg-gray-100 dark:bg-zinc-800/50 hover:bg-zinc-700/50 z-30"
-                    aria-label="Open sidebar"
-                    aria-expanded="false"
+                    aria-label="Toggle sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <Menu className="w-5 h-5 text-zinc-400" />
                 </Button>
@@ -102,7 +103,8 @@ export const Sidebar = () => {
                     variant="ghost"
                     size="icon-sm"
                     className="bg-gray-50 dark:bg-zinc-900 border border-white/10 shadow-md hover:bg-gray-200 dark:hover:bg-zinc-800/50"
-                    aria-label="Expand sidebar"
+                    aria-label="Toggle sidebar"
+                    aria-expanded={sidebarOpen}
                 >
                     <ChevronRight className="w-4 h-4 text-zinc-400" />
                 </Button>

--- a/tests/AppShell.test.tsx
+++ b/tests/AppShell.test.tsx
@@ -124,7 +124,7 @@ describe("AppShell Component", () => {
         // Resolve ambiguity by checking for the header title specifically
         expect(screen.getByRole('heading', { name: /Ledger: Test Profile/i })).toBeInTheDocument();
         expect(screen.getByText('Inspector')).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /close sidebar/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /toggle sidebar/i })).toBeInTheDocument();
     });
 
     it("performs initial responsive check on mount", () => {
@@ -169,7 +169,7 @@ describe("AppShell Component", () => {
             </MemoryRouter>
         );
 
-        const toggleBtn = screen.getByRole('button', { name: /close sidebar/i });
+        const toggleBtn = screen.getByRole('button', { name: /toggle sidebar/i });
         fireEvent.click(toggleBtn);
         expect(mockUIState.toggleLeftSidebar).toHaveBeenCalled();
     });


### PR DESCRIPTION
💡 **What**: Replaced dynamic `aria-label` values (like "Open/Close") on panel toggles with static ones (like "Toggle sidebar") and added `aria-expanded` attributes. Also updated corresponding tooltips and tests.
🎯 **Why**: To follow accessibility best practices for toggle states. Dynamic aria labels are an anti-pattern as they require users to understand both states rather than hearing the component's name and its current state.
📸 **Before/After**: Visual changes are nil, but screen reader context is significantly improved. Tooltips now consistently read "Toggle sidebar" or "Toggle inspector".
♿ **Accessibility**: Improved screen reader announcements for panel toggles by explicitly conveying the open/closed state via `aria-expanded`.

---
*PR created automatically by Jules for task [9084632635048942305](https://jules.google.com/task/9084632635048942305) started by @njtan142*