### PR TITLE
⚡ Bolt: Optimize container integrity validation with Map lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2024-05-24 - Map lookups for validation loops
+**Learning:** Using recursive `.find()` checks and `.findIndex()` for integrity validation can lead to O(N^2) lookups. Using `array = array.map()` reassignment inside a `.forEach()` validation loop that iteratively repairs state leads to stale references, high intermediate allocations, and O(N*M) complexity.
+**Action:** Pre-index elements into a `Map` (e.g., `nodesById` and `repairedIndexMap`) for O(1) lookups and mutate elements directly by index (e.g., `repaired[index] = newValue`) when auto-repairing data during validation loops. Always explicitly update the cache Map (`map.set(id, newValue)`) when auto-repairing elements.

--- a/src/features/nodeEditor/utils/validateContainerIntegrity.ts
+++ b/src/features/nodeEditor/utils/validateContainerIntegrity.ts
@@ -25,15 +25,31 @@ export const validateContainerIntegrity = (
     const errors: string[] = [];
     let repaired = [...nodes];
     
+    // O(N) Maps for fast lookups
+    const nodesById = new Map<string, Node>();
+    nodes.forEach(n => nodesById.set(n.id, n));
+
+    const repairedIndexMap = new Map<string, number>();
+    const repairedById = new Map<string, Node>();
+    repaired.forEach((n, idx) => {
+        repairedIndexMap.set(n.id, idx);
+        repairedById.set(n.id, n);
+    });
+
+    const updateRepaired = (index: number, newNode: Node) => {
+        repaired[index] = newNode;
+        repairedById.set(newNode.id, newNode);
+    };
+
     // 1. Check for orphaned children (React Flow v12 uses parentId)
     repaired.forEach((node, index) => {
         if (node.parentId) {
-            const parent = nodes.find(n => n.id === node.parentId);
+            const parent = nodesById.get(node.parentId);
             if (!parent) {
                 errors.push(`Orphaned child: ${node.id} references missing parent ${node.parentId}`);
                 // Auto-repair: clear parentId
                 const { parentId: _, extent: __, ...rest } = node;
-                repaired[index] = rest as Node;
+                updateRepaired(index, rest as Node);
             }
         }
     });
@@ -44,13 +60,13 @@ export const validateContainerIntegrity = (
             const rawChildIds = node.data.childNodeIds;
             const childNodeIds: string[] = Array.isArray(rawChildIds) ? rawChildIds : [];
             const missingChildren = childNodeIds.filter(
-                childId => !nodes.find(n => n.id === childId)
+                childId => !nodesById.has(childId)
             );
             
             if (missingChildren.length > 0) {
                 errors.push(`Container ${node.id} references missing children: ${missingChildren.join(', ')}`);
                 // Auto-repair: remove missing child IDs
-                repaired[index] = {
+                const newNode = {
                     ...node,
                     data: {
                         ...node.data,
@@ -59,19 +75,21 @@ export const validateContainerIntegrity = (
                         ),
                     },
                 };
+                updateRepaired(index, newNode);
             }
             
             // Check that all children actually reference this container (using parentId)
-            const children = nodes.filter(n => childNodeIds.includes(n.id));
+            const children = childNodeIds.map(id => nodesById.get(id)).filter((n): n is Node => n !== undefined);
             const misparentedChildren = children.filter(n => n.parentId !== node.id);
             if (misparentedChildren.length > 0) {
                 errors.push(`Container ${node.id} has children with wrong parentId: ${misparentedChildren.map(n => n.id).join(', ')}`);
                 // Auto-repair: fix parentId on children
-                repaired = repaired.map(n => {
-                    if (misparentedChildren.find(c => c.id === n.id)) {
-                        return { ...n, parentId: node.id, extent: 'parent' as const };
+                misparentedChildren.forEach(c => {
+                    const childIdx = repairedIndexMap.get(c.id);
+                    if (childIdx !== undefined) {
+                        const updatedChild = { ...repaired[childIdx], parentId: node.id, extent: 'parent' as const };
+                        updateRepaired(childIdx, updatedChild);
                     }
-                    return n;
                 });
             }
         }
@@ -81,22 +99,19 @@ export const validateContainerIntegrity = (
     const hasCircularRef = (nodeId: string, visited = new Set<string>()): boolean => {
         if (visited.has(nodeId)) return true;
         visited.add(nodeId);
-        const node = repaired.find(n => n.id === nodeId);
+        const node = repairedById.get(nodeId);
         if (node?.parentId) {
             return hasCircularRef(node.parentId, visited);
         }
         return false;
     };
     
-    repaired.forEach(node => {
+    repaired.forEach((node, index) => {
         if (node.parentId && hasCircularRef(node.id)) {
             errors.push(`Circular reference detected: ${node.id}`);
             // Auto-repair: clear parentId
-            const index = repaired.findIndex(n => n.id === node.id);
-            if (index !== -1) {
-                const { parentId: _, extent: __, ...rest } = node;
-                repaired[index] = rest as Node;
-            }
+            const { parentId: _, extent: __, ...rest } = node;
+            updateRepaired(index, rest as Node);
         }
     });
     
@@ -107,7 +122,7 @@ export const validateContainerIntegrity = (
             if (!data || typeof data !== 'object') {
                 errors.push(`Container ${node.id} has invalid data structure`);
                 // Auto-repair: set default data
-                repaired[index] = {
+                const newNode = {
                     ...node,
                     data: {
                         type: 'container',
@@ -117,13 +132,15 @@ export const validateContainerIntegrity = (
                         createdAt: new Date().toISOString(),
                     },
                 };
+                updateRepaired(index, newNode);
             } else if (data.type !== 'container') {
                 errors.push(`Container ${node.id} has incorrect type discriminator`);
                 // Auto-repair: fix type discriminator
-                repaired[index] = {
+                const newNode = {
                     ...node,
                     data: { ...data, type: 'container' },
                 };
+                updateRepaired(index, newNode);
             }
         }
     });


### PR DESCRIPTION
💡 **What:** 
Replaced O(N^2) `.find()` and `.findIndex()` array lookups inside the container integrity loops with O(1) `Map` lookups (`nodesById`, `repairedIndexMap`, and `repairedById`). Refactored auto-repair logic to mutate array elements directly by index rather than reassigning variables within `forEach` loops, eliminating stale references and reducing excess memory allocation.

🎯 **Why:**
The previous implementation used recursive `.find()` checks and iterative `.filter()` operations over potentially large node arrays. When repairing state, the loop mutated the array variable directly (`repaired = repaired.map(...)`) within the `.forEach` cycle, leaving subsequent iterations operating on stale references while constantly allocating new array instances. 

📊 **Impact:**
- Drastically reduces time complexity for integrity validation from O(N^2) to O(N).
- Prevents redundant array cloning and object allocations during state repair, reducing memory pressure.
- Avoids stale object references during iterative repairs, ensuring correctly validated state.

🔬 **Measurement:**
- Run the full test suite (`pnpm test`) to ensure nodes and containers remain properly validated and repaired. The tests pass identical validation assertions (excluding pre-existing flaky/unrelated tests) while consuming less computational overhead.

---
*PR created automatically by Jules for task [10642631572527831874](https://jules.google.com/task/10642631572527831874) started by @njtan142*