### PR TITLE
🎨 Palette: [UX improvement] Add ARIA state attributes to AppShell header toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2025-06-23 - AppShell Layout Toggles ARIA States
+**Learning:** For layout toggle buttons that expand or collapse sections (such as sidebars or inspector panels), dynamically binding the `aria-expanded` attribute to the boolean visibility state of the target panel is essential. Similarly, view mode or theme toggles should use `aria-pressed`. Static `aria-labels` should be used instead of dynamic labels that change based on state, as state is handled by the ARIA attributes.
+**Action:** Replace dynamic `aria-label` values on layout toggle buttons with static labels (e.g., 'Toggle') combined with explicit state attributes (`aria-expanded` or `aria-pressed`). Ensure tooltip texts exactly match the static `aria-label`.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,14 +397,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
-                                            aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-label="Toggle sidebar"
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}</p>
+                                        <p>Toggle sidebar</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -422,14 +423,15 @@ export const AppShell: React.FC = () => {
                                                 variant="outline"
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
-                                                aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-label="Toggle view mode"
+                                                aria-pressed={dashboardViewMode === 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
                                             </Button>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                            <p>{dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}</p>
+                                            <p>Toggle view mode</p>
                                         </TooltipContent>
                                     </Tooltip>
                                 )}
@@ -439,14 +441,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleTheme}
-                                            aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-label="Toggle theme"
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}</p>
+                                        <p>Toggle theme</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -456,14 +459,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
-                                            aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-label="Toggle inspector"
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{rightInspectorOpen ? 'Close inspector' : 'Open inspector'}</p>
+                                        <p>Toggle inspector</p>
                                     </TooltipContent>
                                 </Tooltip>
                             </div>

--- a/tests/AppShell.test.tsx
+++ b/tests/AppShell.test.tsx
@@ -124,7 +124,7 @@ describe("AppShell Component", () => {
         // Resolve ambiguity by checking for the header title specifically
         expect(screen.getByRole('heading', { name: /Ledger: Test Profile/i })).toBeInTheDocument();
         expect(screen.getByText('Inspector')).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /close sidebar/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /toggle sidebar/i })).toBeInTheDocument();
     });
 
     it("performs initial responsive check on mount", () => {
@@ -169,7 +169,7 @@ describe("AppShell Component", () => {
             </MemoryRouter>
         );
 
-        const toggleBtn = screen.getByRole('button', { name: /close sidebar/i });
+        const toggleBtn = screen.getByRole('button', { name: /toggle sidebar/i });
         fireEvent.click(toggleBtn);
         expect(mockUIState.toggleLeftSidebar).toHaveBeenCalled();
     });


### PR DESCRIPTION
💡 **What**: Replaced dynamic `aria-label`s on AppShell header toggles (sidebar, view mode, theme, inspector) with static values (e.g., "Toggle sidebar") and added dynamic state attributes (`aria-expanded` and `aria-pressed`). Also updated associated tooltip texts to match the static labels and updated test queries.
🎯 **Why**: Screen reader users need to know both what the button controls and its current state. Dynamic ARIA labels obscure the control's primary purpose and can confuse screen readers. `aria-expanded` and `aria-pressed` correctly convey the state.
📸 **Before/After**: N/A (non-visual changes).
♿ **Accessibility**: Significant improvement for screen reader accessibility on the primary navigation controls within the AppShell header by correctly exposing collapsible/toggle states.

---
*PR created automatically by Jules for task [12214943382670848550](https://jules.google.com/task/12214943382670848550) started by @njtan142*