### PR TITLE
⚡ Bolt: optimize calculateBoundingBox with single-pass loop

### DIFF
--- a/src/features/nodeEditor/utils/groupNodes.ts
+++ b/src/features/nodeEditor/utils/groupNodes.ts
@@ -26,15 +26,34 @@ export interface GroupCreationResult {
  * Calculate bounding box of nodes
  */
 export const calculateBoundingBox = (nodes: Node[]): ContainerBounds => {
-    const xs = nodes.map(n => n.position.x);
-    const ys = nodes.map(n => n.position.y);
-    const widths = nodes.map(n => (n.width || 150));
-    const heights = nodes.map(n => (n.height || 100));
-    
-    const minX = Math.min(...xs);
-    const minY = Math.min(...ys);
-    const maxX = Math.max(...xs.map((x, i) => x + widths[i]));
-    const maxY = Math.max(...ys.map((y, i) => y + heights[i]));
+    // ⚡ Bolt: Single-pass loop replaces Map/Spread to avoid Maximum call stack size exceeded
+    if (nodes.length === 0) {
+        return { minX: 0, minY: 0, maxX: 0, maxY: 0, width: 0, height: 0 };
+    }
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        const x = node.position.x;
+        const y = node.position.y;
+
+        // Native Math.min/max parity: propagate NaN
+        if (Number.isNaN(x) || Number.isNaN(y)) {
+            return { minX: NaN, minY: NaN, maxX: NaN, maxY: NaN, width: NaN, height: NaN };
+        }
+
+        const width = node.width || 150;
+        const height = node.height || 100;
+
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x + width > maxX) maxX = x + width;
+        if (y + height > maxY) maxY = y + height;
+    }
     
     return {
         minX,


### PR DESCRIPTION
💡 What: Replaced array spread and map chaining in `calculateBoundingBox` with a single-pass loop.
🎯 Why: To prevent "Maximum call stack size exceeded" errors and O(N) unnecessary allocations when grouping large numbers of nodes.
📊 Impact: O(1) memory overhead and avoids call stack crash for > 100k items.
🔬 Measurement: Run grouping with a large selection of nodes and observe it succeeds without crashing or lag.

---
*PR created automatically by Jules for task [1062587115021094391](https://jules.google.com/task/1062587115021094391) started by @njtan142*