### PR TITLE
⚡ Bolt: Replace chained map/filter/reduce and Math.max spreads with single-pass loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2024-06-29 - Avoid Call Stack Limits with Spread on Large Arrays
+**Learning:** Chaining array methods like `.map().filter().reduce()` along with spread operators (`Math.max(...values)`) is highly inefficient and risks `RangeError: Maximum call stack size exceeded` when dealing with large arrays. Each spread element is placed on the call stack, which creates intermediate allocations.
+**Action:** Replace multi-step array processing and spread syntaxes with a single-pass `for` loop to accumulate required statistics like `min`, `max`, `sum`, and `count` simultaneously.

--- a/src/features/nodeEditor/hooks/useLedgerData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerData.ts
@@ -90,20 +90,31 @@ export async function hydrateLedgerSourceNode(
 
     if (numberFields.length > 0 && filteredEntries.length > 0) {
       numberFields.forEach(field => {
-        const values = filteredEntries
-          .map(e => e.data[field.id])
-          .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
 
-        if (values.length > 0) {
+        for (let i = 0; i < filteredEntries.length; i++) {
+          const value = filteredEntries[i].data[field.id];
+          if (typeof value === 'number' && !isNaN(value)) {
+            sum += value;
+            if (value < min) min = value;
+            if (value > max) max = value;
+            count++;
+          }
+        }
+
+        if (count > 0) {
           aggregates.sum = aggregates.sum || {};
           aggregates.avg = aggregates.avg || {};
           aggregates.min = aggregates.min || {};
           aggregates.max = aggregates.max || {};
 
-          aggregates.sum[field.id] = values.reduce((a, b) => a + b, 0);
-          aggregates.avg[field.id] = aggregates.sum[field.id] / values.length;
-          aggregates.min[field.id] = Math.min(...values);
-          aggregates.max[field.id] = Math.max(...values);
+          aggregates.sum[field.id] = sum;
+          aggregates.avg[field.id] = sum / count;
+          aggregates.min[field.id] = min;
+          aggregates.max[field.id] = max;
         }
       });
     }

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,29 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            let sum = 0;
+            let min = Infinity;
+            let max = -Infinity;
+            let count = 0;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const value = entries[i].data[fieldId];
+                if (typeof value === 'number' && !isNaN(value)) {
+                    sum += value;
+                    if (value < min) min = value;
+                    if (value > max) max = value;
+                    count++;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min: min,
+                    max: max,
+                    count: count,
                 };
             }
         });
@@ -201,17 +212,28 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        let count = 0;
+
+        for (let i = 0; i < entries.length; i++) {
+            const value = entries[i].data[fieldId];
+            if (typeof value === 'number' && !isNaN(value)) {
+                sum += value;
+                if (value < min) min = value;
+                if (value > max) max = value;
+                count++;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min: min,
+            max: max,
+            count: count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
💡 **What**: Replaced chained array processing (`.map().filter().reduce()`) and `Math.max(...values)`/`Math.min(...values)` spread operators with single-pass `for` loops in `useLedgerData` and `useLedgerSourceData` aggregation calculations.

🎯 **Why**: Chained array methods cause intermediate allocations that put pressure on the garbage collector. More critically, applying the spread operator on large data arrays pushes every element onto the call stack, which leads to `RangeError: Maximum call stack size exceeded` crashes when the ledger source scales to thousands of items.

📊 **Impact**: Prevents catastrophic app crashes for datasets exceeding the V8 engine call stack limit (~10k-100k items) while significantly reducing CPU cycles and intermediate memory usage required for aggregate calculations.

🔬 **Measurement**: Verify by importing or generating an extremely large ledger dataset (>10,000 entries) and observing that the LedgerSourceNode resolves correctly and displays aggregates without failing, whereas the previous implementation would crash the browser tab or throw maximum call stack size exceeded exceptions.

---
*PR created automatically by Jules for task [15969716245290022233](https://jules.google.com/task/15969716245290022233) started by @njtan142*