### PR TITLE
⚡ Bolt: Replace Math.min/max spreads with single-pass loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-05-28 - Replace Math.min/max spreads and chained maps/filters with single-pass loops for aggregates
+**Learning:** In `useLedgerSourceData` and `useLedgerData`, using chained `.map().filter()` to process data and extracting aggregates using `Math.min(...values)` and `Math.max(...values)` creates significant GC pressure and can result in "Maximum call stack size exceeded" errors with larger array sizes due to argument spreads. This O(N) operations x N times iterating structure reduces rendering and hydration speed.
+**Action:** Replace functional array method chains (map/filter) and spread operators over variable-length arrays (`...values`) with explicit, single-pass `for` loops. Doing so avoids unbounded call stacks and reduces O(N) coefficient to improve high frequency update loops like dashboard and UI re-renders.

--- a/src/features/nodeEditor/hooks/useLedgerData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerData.ts
@@ -90,20 +90,31 @@ export async function hydrateLedgerSourceNode(
 
     if (numberFields.length > 0 && filteredEntries.length > 0) {
       numberFields.forEach(field => {
-        const values = filteredEntries
-          .map(e => e.data[field.id])
-          .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let count = 0;
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
 
-        if (values.length > 0) {
+        for (let i = 0; i < filteredEntries.length; i++) {
+          const val = filteredEntries[i].data[field.id];
+          if (typeof val === 'number' && !isNaN(val)) {
+            sum += val;
+            count++;
+            if (val < min) min = val;
+            if (val > max) max = val;
+          }
+        }
+
+        if (count > 0) {
           aggregates.sum = aggregates.sum || {};
           aggregates.avg = aggregates.avg || {};
           aggregates.min = aggregates.min || {};
           aggregates.max = aggregates.max || {};
 
-          aggregates.sum[field.id] = values.reduce((a, b) => a + b, 0);
-          aggregates.avg[field.id] = aggregates.sum[field.id] / values.length;
-          aggregates.min[field.id] = Math.min(...values);
-          aggregates.max[field.id] = Math.max(...values);
+          aggregates.sum[field.id] = sum;
+          aggregates.avg[field.id] = sum / count;
+          aggregates.min[field.id] = min;
+          aggregates.max[field.id] = max;
         }
       });
     }

--- a/src/features/nodeEditor/hooks/useLedgerSourceData.ts
+++ b/src/features/nodeEditor/hooks/useLedgerSourceData.ts
@@ -54,18 +54,29 @@ export const useLedgerSourceData = (
 
         // Calculate stats for each field that contains numbers
         fieldIds.forEach(fieldId => {
-            const values = entries
-                .map(e => e.data[fieldId])
-                .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+            let count = 0;
+            let sum = 0;
+            let min = Infinity;
+            let max = -Infinity;
 
-            if (values.length === 0) {
+            for (let i = 0; i < entries.length; i++) {
+                const val = entries[i].data[fieldId];
+                if (typeof val === 'number' && !isNaN(val)) {
+                    sum += val;
+                    count++;
+                    if (val < min) min = val;
+                    if (val > max) max = val;
+                }
+            }
+
+            if (count === 0) {
                 result[fieldId] = null;
             } else {
                 result[fieldId] = {
-                    avg: values.reduce((a, b) => a + b, 0) / values.length,
-                    min: Math.min(...values),
-                    max: Math.max(...values),
-                    count: values.length,
+                    avg: sum / count,
+                    min,
+                    max,
+                    count,
                 };
             }
         });
@@ -201,17 +212,28 @@ export const useFieldStats = (
     return useMemo(() => {
         if (entries.length === 0) return null;
         
-        const values = entries
-            .map(e => e.data[fieldId])
-            .filter((v): v is number => typeof v === 'number' && !isNaN(v));
+        let count = 0;
+        let sum = 0;
+        let min = Infinity;
+        let max = -Infinity;
+
+        for (let i = 0; i < entries.length; i++) {
+            const val = entries[i].data[fieldId];
+            if (typeof val === 'number' && !isNaN(val)) {
+                sum += val;
+                count++;
+                if (val < min) min = val;
+                if (val > max) max = val;
+            }
+        }
         
-        if (values.length === 0) return null;
+        if (count === 0) return null;
         
         return {
-            avg: values.reduce((a, b) => a + b, 0) / values.length,
-            min: Math.min(...values),
-            max: Math.max(...values),
-            count: values.length,
+            avg: sum / count,
+            min,
+            max,
+            count,
         };
     }, [entries, fieldId]);
 };


### PR DESCRIPTION
💡 **What**: Replaced functional array method chains (`.map().filter()`) and spread operators over variable-length arrays (`...values`) with explicit, single-pass `for` loops in `useLedgerSourceData` and `useLedgerData` when calculating ledger aggregates.

🎯 **Why**: Using chained `.map().filter()` creates intermediate arrays that increase Garbage Collection (GC) pressure. Additionally, extracting aggregates using `Math.min(...values)` and `Math.max(...values)` places elements on the call stack and can cause a "Maximum call stack size exceeded" error when processing very large arrays (typically > 65k elements). 

📊 **Impact**: Reduces O(N) operations coefficient, limits GC overhead by avoiding intermediate allocations, and completely avoids unbounded call stack crashes for large data sets, improving hydration and rendering speed.

🔬 **Measurement**: Verified the logic equivalence and lack of regressions by successfully running the unit test suite (`pnpm test src/tests/features/nodeEditor/useLedgerData.test.ts`).

---
*PR created automatically by Jules for task [1368615101985517053](https://jules.google.com/task/1368615101985517053) started by @njtan142*