### PR TITLE
🎨 Palette: Standardize icon-only toggle buttons ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2026-07-03 - Ensure Static ARIA Labels for Toggle Buttons
+**Learning:** Dynamic `aria-label` attributes on toggle buttons (e.g., "Open/Close sidebar" or "Switch to Light/Dark Mode") provide confusing or conflicting state information when read by screen readers. It is better to use static, unchanging `aria-label` strings combined with explicit state attributes (`aria-expanded` for visibility toggles, `aria-pressed` for mode toggles).
+**Action:** When creating toggle buttons, use static `aria-label` (like "Toggle sidebar" or "Toggle theme") and bind the current state to `aria-expanded={isOpen}` or `aria-pressed={isActive}` to communicate state clearly.

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,14 +397,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
-                                            aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-label="Toggle sidebar"
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}</p>
+                                        <p>Toggle sidebar</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -422,14 +423,15 @@ export const AppShell: React.FC = () => {
                                                 variant="outline"
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
-                                                aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-label="Toggle view mode"
+                                                aria-pressed={dashboardViewMode !== 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
                                             </Button>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                            <p>{dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}</p>
+                                            <p>Toggle view mode</p>
                                         </TooltipContent>
                                     </Tooltip>
                                 )}
@@ -439,14 +441,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleTheme}
-                                            aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-label="Toggle theme"
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}</p>
+                                        <p>Toggle theme</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -456,14 +459,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
-                                            aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-label="Toggle inspector"
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{rightInspectorOpen ? 'Close inspector' : 'Open inspector'}</p>
+                                        <p>Toggle inspector</p>
                                     </TooltipContent>
                                 </Tooltip>
                             </div>

--- a/src/features/profiles/ProfileSelector.tsx
+++ b/src/features/profiles/ProfileSelector.tsx
@@ -137,7 +137,8 @@ export const ProfileSelector: React.FC = () => {
                 onClick={toggleTheme}
                 variant="outline"
                 size="icon"
-                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-label="Toggle theme"
+                aria-pressed={theme === 'dark'}
                 className="absolute top-8 right-8 bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 dark:hover:text-emerald-400 hover:border-emerald-500/50 focus:ring-emerald-500/50"
             >
                 {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}

--- a/src/features/profiles/WelcomePage.test.tsx
+++ b/src/features/profiles/WelcomePage.test.tsx
@@ -87,7 +87,7 @@ describe('WelcomePage', () => {
 
     it('theme toggle button is present with accessible label', () => {
         renderWithRouter(<WelcomePage />);
-        const themeToggle = screen.getByRole('button', { name: /switch to light mode/i });
+        const themeToggle = screen.getByRole('button', { name: /toggle theme/i });
         expect(themeToggle).toBeDefined();
         expect(themeToggle.tagName).toBe('BUTTON');
     });

--- a/src/features/profiles/WelcomePage.tsx
+++ b/src/features/profiles/WelcomePage.tsx
@@ -27,7 +27,8 @@ export const WelcomePage: React.FC = () => {
                 onClick={toggleTheme}
                 variant="outline"
                 size="icon"
-                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-label="Toggle theme"
+                aria-pressed={theme === 'dark'}
                 className="absolute top-8 right-8 p-3 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 dark:hover:text-emerald-400 hover:border-emerald-500/50 transition-all duration-300 shadow-sm focus:ring-2 focus:ring-emerald-500/50"
             >
                 {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}

--- a/tests/AppShell.test.tsx
+++ b/tests/AppShell.test.tsx
@@ -124,7 +124,7 @@ describe("AppShell Component", () => {
         // Resolve ambiguity by checking for the header title specifically
         expect(screen.getByRole('heading', { name: /Ledger: Test Profile/i })).toBeInTheDocument();
         expect(screen.getByText('Inspector')).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /close sidebar/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /toggle sidebar/i })).toBeInTheDocument();
     });
 
     it("performs initial responsive check on mount", () => {
@@ -169,7 +169,7 @@ describe("AppShell Component", () => {
             </MemoryRouter>
         );
 
-        const toggleBtn = screen.getByRole('button', { name: /close sidebar/i });
+        const toggleBtn = screen.getByRole('button', { name: /toggle sidebar/i });
         fireEvent.click(toggleBtn);
         expect(mockUIState.toggleLeftSidebar).toHaveBeenCalled();
     });


### PR DESCRIPTION
💡 **What:** Standardized `aria-label` attributes on icon-only toggle buttons (Sidebar, Inspector, Theme, View Mode) across `AppShell` and Profile pages.
🎯 **Why:** Dynamic `aria-label` texts (like "Switch to Light Mode" then "Switch to Dark Mode") can cause confusion for screen reader users and don't cleanly convey the element's functional role. Using static labels alongside stateful attributes provides clearer structural context.
📸 **Before/After:** Functionally the same visually, but tooltips and accessibility trees now reflect static names like "Toggle theme" with `aria-pressed="true"`.
♿ **Accessibility:** Replaced dynamic `aria-label` on toggles with static text and explicitly bound current state to `aria-pressed` or `aria-expanded`. Updated associated tooltips to match static labels for consistency.

---
*PR created automatically by Jules for task [8178522988565202155](https://jules.google.com/task/8178522988565202155) started by @njtan142*