### PR TITLE
⚡ Bolt: Optimize node data change detection in edgeDataFlow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2026-07-09 - Optimize state subscriptions with O(1) Map lookups and reference checks
+**Learning:** In Zustand state subscriptions comparing large arrays (e.g., node editor state), using `Array.prototype.find` inside an array filter creates an O(N^2) complexity that blocks the UI thread. Additionally, unconditionally calling `JSON.stringify` for deep comparison is an expensive operation that is often unnecessary if the object reference hasn't changed.
+**Action:** Always index previous arrays into a `Map` keyed by ID for O(1) lookups before filtering. Furthermore, implement a fast identity/reference check (`currentNode.data === previousNode.data`) to bypass expensive serialization overhead for unmodified items.

--- a/src/features/nodeEditor/utils/edgeDataFlow.ts
+++ b/src/features/nodeEditor/utils/edgeDataFlow.ts
@@ -163,10 +163,19 @@ export function setupNodeDataChangeSubscription(): () => void {
     const unsubscribe = useNodeStore.subscribe(
         (state) => state.nodes, // Select only nodes array
         (currentNodes, previousNodes) => {
+            // Index previous nodes for O(1) lookup
+            const previousNodesMap = new Map();
+            for (let i = 0; i < previousNodes.length; i++) {
+                previousNodesMap.set(previousNodes[i].id, previousNodes[i]);
+            }
+
             // Find nodes whose data has changed
             const changedNodes = currentNodes.filter(currentNode => {
-                const previousNode = previousNodes.find(p => p.id === currentNode.id);
+                const previousNode = previousNodesMap.get(currentNode.id);
                 if (!previousNode) return false; // New node, not a change
+
+                // Fast identity check before expensive serialization
+                if (currentNode.data === previousNode.data) return false;
 
                 // Compare data objects (shallow comparison)
                 return JSON.stringify(currentNode.data) !== JSON.stringify(previousNode.data);

--- a/src/features/nodeEditor/utils/edgeDataFlow.ts
+++ b/src/features/nodeEditor/utils/edgeDataFlow.ts
@@ -1,5 +1,4 @@
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { CanvasNode, CanvasEdge } from '../../../types/nodeEditor';
 
 /**
  * Get the current output data from a source node

--- a/src/tests/features/nodeEditor/utils/edgeDataFlow.test.ts
+++ b/src/tests/features/nodeEditor/utils/edgeDataFlow.test.ts
@@ -457,7 +457,7 @@ describe('edgeDataFlow', () => {
 
         it('should propagate changes when node data changes', () => {
             const mockUnsubscribe = vi.fn();
-            (useNodeStore.subscribe as any).mockImplementation((selector, listener) => {
+            (useNodeStore.subscribe as any).mockImplementation((_selector: any, listener: any) => {
                 // Simulate calling the listener with changed nodes
                 const currentNodes = [
                     { id: 'node1', type: 'ledgerSource', data: { entries: [1, 2, 3] } }


### PR DESCRIPTION
💡 What: Replaced O(N^2) array lookup with O(N) Map lookup and added identity check before deep serialization.
🎯 Why: To prevent UI thread blocking and reduce CPU overhead during high-frequency node data updates in the canvas.
📊 Impact: Converts an O(N^2) operation to O(N) and bypasses expensive `JSON.stringify` calls for unchanged node data.
🔬 Measurement: Observe CPU usage during bulk node data updates and run unit tests.

---
*PR created automatically by Jules for task [16064994144997873377](https://jules.google.com/task/16064994144997873377) started by @njtan142*