### PR TITLE
🎨 Palette: Add aria-pressed and static aria-labels to toggle buttons

### DIFF
--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -397,14 +397,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleLeftSidebar}
-                                            aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-label="Toggle sidebar"
+                                            aria-expanded={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}</p>
+                                        <p>Toggle sidebar</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -422,14 +423,15 @@ export const AppShell: React.FC = () => {
                                                 variant="outline"
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
-                                                aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-label="Toggle view mode"
+                                                aria-pressed={dashboardViewMode !== 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
                                             </Button>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                            <p>{dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}</p>
+                                            <p>Toggle view mode</p>
                                         </TooltipContent>
                                     </Tooltip>
                                 )}
@@ -439,14 +441,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleTheme}
-                                            aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-label="Toggle theme"
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}</p>
+                                        <p>Toggle theme</p>
                                     </TooltipContent>
                                 </Tooltip>
                                 <div className="h-4 w-px bg-zinc-200 dark:bg-zinc-800" />
@@ -456,14 +459,15 @@ export const AppShell: React.FC = () => {
                                             variant="outline"
                                             size="icon"
                                             onClick={toggleRightInspector}
-                                            aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-label="Toggle inspector"
+                                            aria-expanded={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        <p>{rightInspectorOpen ? 'Close inspector' : 'Open inspector'}</p>
+                                        <p>Toggle inspector</p>
                                     </TooltipContent>
                                 </Tooltip>
                             </div>

--- a/src/features/profiles/ProfileSelector.tsx
+++ b/src/features/profiles/ProfileSelector.tsx
@@ -137,7 +137,8 @@ export const ProfileSelector: React.FC = () => {
                 onClick={toggleTheme}
                 variant="outline"
                 size="icon"
-                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-label="Toggle theme"
+                aria-pressed={theme === 'dark'}
                 className="absolute top-8 right-8 bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 dark:hover:text-emerald-400 hover:border-emerald-500/50 focus:ring-emerald-500/50"
             >
                 {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}

--- a/src/features/profiles/WelcomePage.test.tsx
+++ b/src/features/profiles/WelcomePage.test.tsx
@@ -87,7 +87,7 @@ describe('WelcomePage', () => {
 
     it('theme toggle button is present with accessible label', () => {
         renderWithRouter(<WelcomePage />);
-        const themeToggle = screen.getByRole('button', { name: /switch to light mode/i });
+        const themeToggle = screen.getByRole('button', { name: /toggle theme/i });
         expect(themeToggle).toBeDefined();
         expect(themeToggle.tagName).toBe('BUTTON');
     });

--- a/src/features/profiles/WelcomePage.tsx
+++ b/src/features/profiles/WelcomePage.tsx
@@ -27,7 +27,8 @@ export const WelcomePage: React.FC = () => {
                 onClick={toggleTheme}
                 variant="outline"
                 size="icon"
-                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-label="Toggle theme"
+                aria-pressed={theme === 'dark'}
                 className="absolute top-8 right-8 p-3 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 dark:hover:text-emerald-400 hover:border-emerald-500/50 transition-all duration-300 shadow-sm focus:ring-2 focus:ring-emerald-500/50"
             >
                 {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}


### PR DESCRIPTION
💡 What: Replaced dynamic aria-labels with static labels and added `aria-pressed` or `aria-expanded` attributes to icon-only toggle buttons across AppShell, WelcomePage, and ProfileSelector. Made tooltips match static aria-labels.
🎯 Why: To improve screen reader experience by conveying the active state of toggleable buttons, as dynamic labels alone are insufficient.
📸 Before/After: Before, buttons used changing labels like "Switch to Light Mode". After, they use a static label "Toggle theme" with `aria-pressed={theme === 'dark'}`.
♿ Accessibility: Screen reader users can now understand if a toggle is currently active or not.

---
*PR created automatically by Jules for task [17942318661082457801](https://jules.google.com/task/17942318661082457801) started by @njtan142*