### PR TITLE
🎨 Palette: Improve accessibility of display toggle buttons in node editor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2026-07-13 - Prevent Conflicting ARIA Toggle States
+**Learning:** While `aria-pressed` is used for active toggle states, it must never be combined with `aria-expanded` on the same element. Using both creates an ARIA anti-pattern that confuses screen readers (e.g., announcing 'button, expanded, pressed'). A button must act as either a toggle button (`aria-pressed`) or a disclosure button (`aria-expanded`), but not both.
+**Action:** When adding `aria-pressed` to toggle buttons, verify that `aria-expanded` is not already present, and explicitly update dynamic `aria-label`s to static ones.

--- a/src/features/nodeEditor/nodes/LedgerSourceNode.tsx
+++ b/src/features/nodeEditor/nodes/LedgerSourceNode.tsx
@@ -331,7 +331,8 @@ export const LedgerSourceNode: React.FC<NodeProps> = React.memo(({ id, data, sel
                                     size="icon-xs"
                                     onClick={() => updateNodeData(id, { showFieldTypes: !showFieldTypes })}
                                     className={`h-5 w-8 ${showFieldTypes ? 'bg-emerald-600' : ''}`}
-                                    aria-label={showFieldTypes ? 'Hide field types' : 'Show field types'}
+                                    aria-label="Toggle field types display"
+                                    aria-pressed={showFieldTypes}
                                 >
                                     <span className="text-[10px]">{showFieldTypes ? 'On' : 'Off'}</span>
                                 </Button>
@@ -345,7 +346,8 @@ export const LedgerSourceNode: React.FC<NodeProps> = React.memo(({ id, data, sel
                                     size="icon-xs"
                                     onClick={() => updateNodeData(id, { showLatestValues: !showLatestValues })}
                                     className={`h-5 w-8 ${showLatestValues ? 'bg-emerald-600' : ''}`}
-                                    aria-label={showLatestValues ? 'Hide latest values' : 'Show latest values'}
+                                    aria-label="Toggle latest values display"
+                                    aria-pressed={showLatestValues}
                                 >
                                     <span className="text-[10px]">{showLatestValues ? 'On' : 'Off'}</span>
                                 </Button>


### PR DESCRIPTION
💡 What: Added `aria-pressed` to the display options toggle buttons (show field types and show latest values) in the LedgerSourceNode, and changed their dynamic `aria-label`s to standard static `aria-label`s.

🎯 Why: To properly communicate toggle state for screen reader users and align with ARIA authoring standards. 

📸 Before/After:
Before: `aria-label="Show field types"` / `aria-label="Hide field types"`
After: `aria-label="Toggle field types display" aria-pressed={true|false}`

♿ Accessibility: Fixes a dynamic label anti-pattern and communicates toggle states effectively to screen reader users using standard ARIA patterns.

---
*PR created automatically by Jules for task [6668325740771230815](https://jules.google.com/task/6668325740771230815) started by @njtan142*