### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure random UUID fallback

### DIFF
--- a/src/features/nodeEditor/NodeCanvas.tsx
+++ b/src/features/nodeEditor/NodeCanvas.tsx
@@ -45,6 +45,7 @@ import { setupSchemaChangeSubscription } from './utils/schemaChangeHandler';
 import { unsubscribeAll, unsubscribeNode, getActiveSubscriptionCount, getTotalConsumerCount } from './utils/subscriptionRegistry';
 import { logSubscriptionCount, logHydrationSummary } from './utils/performanceMonitor';
 import { useLedgerStore } from '../../stores/useLedgerStore';
+import { v4 as uuidv4 } from 'uuid';
 
 // --- STABLE CONFIGURATION (Outside component to prevent re-renders) ---
 
@@ -573,12 +574,8 @@ const generateNodeId = (): string => {
     } catch {
         // crypto.randomUUID may throw in insecure contexts
     }
-    // Fallback: generate UUID v4 manually
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-        const r = Math.random() * 16 | 0;
-        const v = c === 'x' ? r : (r & 0x3 | 0x8);
-        return v.toString(16);
-    });
+    // Fallback: use uuid package
+    return uuidv4();
 };
 
     const handleAddFirstNode = useCallback(() => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `generateNodeId` fallback function used `Math.random()` to generate UUIDs when `crypto.randomUUID` is unavailable. `Math.random()` is not cryptographically secure, which could lead to predictable or colliding IDs.
🎯 Impact: An attacker could potentially predict identifiers, leading to collisions or spoofing of node entries in insecure browser environments.
🔧 Fix: Replaced the manual UUID generation logic with `uuidv4()` from the `uuid` package, ensuring secure and standards-compliant UUID generation even in the fallback path.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. Verified the diff shows correct use of `uuidv4()`.

---
*PR created automatically by Jules for task [9725150649847467931](https://jules.google.com/task/9725150649847467931) started by @njtan142*