### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders in NavigationToolbar

### DIFF
--- a/src/features/nodeEditor/components/NavigationToolbar.tsx
+++ b/src/features/nodeEditor/components/NavigationToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { Maximize2, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { useShallow } from 'zustand/react/shallow';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -23,7 +22,7 @@ export const NavigationToolbar: React.FC = () => {
     const [isFitDisabled, setIsFitDisabled] = useState(false);
 
     // Subscribe to nodes count to determine if fit view should be disabled
-    const nodes = useNodeStore(useShallow(s => s.nodes));
+    const nodesLength = useNodeStore(s => s.nodes.length);
 
     // Update zoom level on viewport changes (event-driven, not polling)
     useEffect(() => {
@@ -32,7 +31,7 @@ export const NavigationToolbar: React.FC = () => {
         const updateZoom = () => {
             const currentZoom = reactFlow.getZoom();
             setZoom(currentZoom);
-            setIsFitDisabled(nodes.length === 0);
+            setIsFitDisabled(nodesLength === 0);
         };
 
         // Initial update
@@ -57,7 +56,7 @@ export const NavigationToolbar: React.FC = () => {
             unsubscribe();
             if (timeoutId) window.clearTimeout(timeoutId);
         };
-    }, [reactFlow, nodes.length]);
+    }, [reactFlow, nodesLength]);
 
     // Defensive: verify we're inside provider
     if (!reactFlow) {
@@ -68,7 +67,7 @@ export const NavigationToolbar: React.FC = () => {
 
     // Zoom to fit implementation
     const handleFitView = useCallback(() => {
-        if (nodes.length === 0) {
+        if (nodesLength === 0) {
             // Button should be disabled, but guard anyway
             return;
         }
@@ -79,7 +78,7 @@ export const NavigationToolbar: React.FC = () => {
             maxZoom: 2.0,
             includeHiddenNodes: false,
         });
-    }, [fitView, nodes.length]);
+    }, [fitView, nodesLength]);
 
     // Zoom in with animation
     const handleZoomIn = useCallback(() => {


### PR DESCRIPTION
💡 **What**: Changed the Zustand selector in `NavigationToolbar` from subscribing to the entire nodes array via `useShallow` to simply subscribing to the primitive `s.nodes.length`.
🎯 **Why**: When moving nodes around the canvas, their individual state (like x/y coordinates) rapidly changes. With `useShallow`, the toolbar was unnecessarily re-rendering on every single node update, causing main thread churn.
📊 **Impact**: Reduces unnecessary `NavigationToolbar` re-renders by 100% during node drag operations, saving CPU cycles and improving canvas interaction smoothness.
🔬 **Measurement**: Verify by turning on React DevTools "Highlight updates when components render" and dragging a node around the canvas. The navigation toolbar will no longer flash/re-render.

---
*PR created automatically by Jules for task [7016379289776014249](https://jules.google.com/task/7016379289776014249) started by @njtan142*