### PR TITLE
🎨 Palette: Add keyboard accessibility to Force Sync button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+## 2025-02-23 - Interactive divs need button role and keyboard handlers
+**Learning:** When using a div with an onClick handler (like the Direct Sync trigger button), it inherently lacks keyboard accessibility and semantic meaning. Screen reader users and keyboard navigators will be unable to interact with it.
+**Action:** Always add role="button", tabIndex={0}, aria-label (if icon-only), and an onKeyDown handler (supporting Space and Enter) to any interactive div acting as a button.

--- a/src/features/sync/SyncStatusButton.test.tsx
+++ b/src/features/sync/SyncStatusButton.test.tsx
@@ -58,4 +58,45 @@ describe('SyncStatusButton', () => {
         fireEvent.click(screen.getByTitle('Open Sync Settings'));
         expect(handleClick).toHaveBeenCalled();
     });
+
+    it('triggers sync when force sync button is clicked', () => {
+        const mockTriggerSync = vi.fn();
+        (useSyncStore as any).mockReturnValue({
+            syncStatus: { status: 'idle' },
+            isLoading: false,
+            triggerSync: mockTriggerSync
+        });
+        (useAuthStore as any).mockReturnValue({ isUnlocked: true });
+
+        render(<SyncStatusButton profileId="test-id" onClick={() => { }} />);
+
+        const forceSyncButton = screen.getByRole('button', { name: 'Force Sync Now' });
+        fireEvent.click(forceSyncButton);
+
+        expect(mockTriggerSync).toHaveBeenCalledWith('test-id');
+    });
+
+    it('triggers sync when force sync button is activated via keyboard', () => {
+        const mockTriggerSync = vi.fn();
+        (useSyncStore as any).mockReturnValue({
+            syncStatus: { status: 'idle' },
+            isLoading: false,
+            triggerSync: mockTriggerSync
+        });
+        (useAuthStore as any).mockReturnValue({ isUnlocked: true });
+
+        render(<SyncStatusButton profileId="test-id" onClick={() => { }} />);
+
+        const forceSyncButton = screen.getByRole('button', { name: 'Force Sync Now' });
+
+        // Test Enter key
+        fireEvent.keyDown(forceSyncButton, { key: 'Enter', code: 'Enter' });
+        expect(mockTriggerSync).toHaveBeenCalledWith('test-id');
+
+        mockTriggerSync.mockClear();
+
+        // Test Space key
+        fireEvent.keyDown(forceSyncButton, { key: ' ', code: 'Space' });
+        expect(mockTriggerSync).toHaveBeenCalledWith('test-id');
+    });
 });

--- a/src/features/sync/SyncStatusButton.tsx
+++ b/src/features/sync/SyncStatusButton.tsx
@@ -71,9 +71,16 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({ profileId, o
         return `${diffDays}d ago`;
     };
 
-    const handleSyncClick = (e: React.MouseEvent) => {
+    const handleSyncClick = (e: React.MouseEvent | React.KeyboardEvent) => {
         e.stopPropagation();
         triggerSync(profileId);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSyncClick(e);
+        }
     };
 
     return (
@@ -99,14 +106,8 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({ profileId, o
                 tabIndex={0}
                 aria-label="Force Sync Now"
                 onClick={handleSyncClick}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleSyncClick(e as any);
-                    }
-                }}
-                className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-600 text-zinc-400 hover:text-emerald-500 transition-all"
+                onKeyDown={handleKeyDown}
+                className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-600 text-zinc-400 hover:text-emerald-500 transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 dark:focus:ring-offset-zinc-800"
                 title="Force Sync Now"
             >
                 <RefreshCw size={12} className={isLoading || syncStatus.status === 'syncing' ? 'animate-spin' : ''} />

--- a/src/features/sync/SyncStatusButton.tsx
+++ b/src/features/sync/SyncStatusButton.tsx
@@ -95,7 +95,17 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({ profileId, o
 
             {/* Direct Sync Trigger Button */}
             <div
+                role="button"
+                tabIndex={0}
+                aria-label="Force Sync Now"
                 onClick={handleSyncClick}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        handleSyncClick(e as any);
+                    }
+                }}
                 className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-600 text-zinc-400 hover:text-emerald-500 transition-all"
                 title="Force Sync Now"
             >


### PR DESCRIPTION
💡 What: Added keyboard accessibility (`role`, `tabIndex`, `onKeyDown`) to the "Force Sync Now" interaction `div` in `SyncStatusButton.tsx`.
🎯 Why: The sync button had an `onClick` handler on a generic `div` without any keyboard support, making it inaccessible to keyboard users and screen readers.
📸 Before/After: N/A - visual appearance remains unchanged, but keyboard focus and interaction now works correctly.
♿ Accessibility: Ensures users navigating via keyboard can trigger the forced sync action by pressing Enter or Space when the sync icon is focused.

---
*PR created automatically by Jules for task [3240555149069690504](https://jules.google.com/task/3240555149069690504) started by @njtan142*