### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders in NavigationToolbar

### DIFF
--- a/src/features/nodeEditor/components/NavigationToolbar.tsx
+++ b/src/features/nodeEditor/components/NavigationToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { Maximize2, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { useShallow } from 'zustand/react/shallow';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -23,7 +22,8 @@ export const NavigationToolbar: React.FC = () => {
     const [isFitDisabled, setIsFitDisabled] = useState(false);
 
     // Subscribe to nodes count to determine if fit view should be disabled
-    const nodes = useNodeStore(useShallow(s => s.nodes));
+    // Optimized: Select primitive property directly to prevent unnecessary component re-renders
+    const nodeCount = useNodeStore(s => s.nodes.length);
 
     // Update zoom level on viewport changes (event-driven, not polling)
     useEffect(() => {
@@ -32,7 +32,7 @@ export const NavigationToolbar: React.FC = () => {
         const updateZoom = () => {
             const currentZoom = reactFlow.getZoom();
             setZoom(currentZoom);
-            setIsFitDisabled(nodes.length === 0);
+            setIsFitDisabled(nodeCount === 0);
         };
 
         // Initial update
@@ -57,7 +57,7 @@ export const NavigationToolbar: React.FC = () => {
             unsubscribe();
             if (timeoutId) window.clearTimeout(timeoutId);
         };
-    }, [reactFlow, nodes.length]);
+    }, [reactFlow, nodeCount]);
 
     // Defensive: verify we're inside provider
     if (!reactFlow) {
@@ -68,7 +68,7 @@ export const NavigationToolbar: React.FC = () => {
 
     // Zoom to fit implementation
     const handleFitView = useCallback(() => {
-        if (nodes.length === 0) {
+        if (nodeCount === 0) {
             // Button should be disabled, but guard anyway
             return;
         }
@@ -79,7 +79,7 @@ export const NavigationToolbar: React.FC = () => {
             maxZoom: 2.0,
             includeHiddenNodes: false,
         });
-    }, [fitView, nodes.length]);
+    }, [fitView, nodeCount]);
 
     // Zoom in with animation
     const handleZoomIn = useCallback(() => {


### PR DESCRIPTION
💡 What: Changed the Zustand selector in `NavigationToolbar.tsx` to select only the `nodes.length` primitive directly rather than selecting the entire `nodes` array collection using `useShallow`.

🎯 Why: The toolbar component was re-rendering unnecessarily every time any node property changed (such as during active node dragging or when a node was edited). Because it only needed the actual node count to determine whether the "Fit to Screen" button should be disabled, selecting just the length primitive via Zustand's default strict equality prevents these wasteful renders.

📊 Impact: Significantly reduces component re-renders of the NavigationToolbar during canvas interactions (like dragging nodes), freeing up the main thread and keeping the UI responsive.

🔬 Measurement: Observe the React DevTools Profiler while dragging nodes across the canvas; the NavigationToolbar component will no longer re-render.

---
*PR created automatically by Jules for task [3436541718746797366](https://jules.google.com/task/3436541718746797366) started by @njtan142*