### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders in NavigationToolbar

### DIFF
--- a/src/features/nodeEditor/components/NavigationToolbar.tsx
+++ b/src/features/nodeEditor/components/NavigationToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { Maximize2, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { useShallow } from 'zustand/react/shallow';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -23,7 +22,8 @@ export const NavigationToolbar: React.FC = () => {
     const [isFitDisabled, setIsFitDisabled] = useState(false);
 
     // Subscribe to nodes count to determine if fit view should be disabled
-    const nodes = useNodeStore(useShallow(s => s.nodes));
+    // Only select the length to prevent unnecessary re-renders when nodes are updated
+    const nodeCount = useNodeStore(s => s.nodes.length);
 
     // Update zoom level on viewport changes (event-driven, not polling)
     useEffect(() => {
@@ -32,7 +32,7 @@ export const NavigationToolbar: React.FC = () => {
         const updateZoom = () => {
             const currentZoom = reactFlow.getZoom();
             setZoom(currentZoom);
-            setIsFitDisabled(nodes.length === 0);
+            setIsFitDisabled(nodeCount === 0);
         };
 
         // Initial update
@@ -57,7 +57,7 @@ export const NavigationToolbar: React.FC = () => {
             unsubscribe();
             if (timeoutId) window.clearTimeout(timeoutId);
         };
-    }, [reactFlow, nodes.length]);
+    }, [reactFlow, nodeCount]);
 
     // Defensive: verify we're inside provider
     if (!reactFlow) {
@@ -68,7 +68,7 @@ export const NavigationToolbar: React.FC = () => {
 
     // Zoom to fit implementation
     const handleFitView = useCallback(() => {
-        if (nodes.length === 0) {
+        if (nodeCount === 0) {
             // Button should be disabled, but guard anyway
             return;
         }
@@ -79,7 +79,7 @@ export const NavigationToolbar: React.FC = () => {
             maxZoom: 2.0,
             includeHiddenNodes: false,
         });
-    }, [fitView, nodes.length]);
+    }, [fitView, nodeCount]);
 
     // Zoom in with animation
     const handleZoomIn = useCallback(() => {


### PR DESCRIPTION
💡 What: Refactored `NavigationToolbar` to select `nodes.length` from the Zustand store instead of mapping over the entire `nodes` array with `useShallow`.
🎯 Why: The previous implementation caused the NavigationToolbar to unnecessarily re-render anytime a node was modified (e.g., dragged on the canvas) because a new nodes array reference would be created, even though the toolbar only cares about the total count of nodes to enable/disable the "Fit View" button.
📊 Impact: Eliminates a major source of unnecessary re-renders in the node editor during typical user interactions like dragging nodes or changing selection state.
🔬 Measurement: Verify by interacting with nodes on the canvas and observing that the `NavigationToolbar` component no longer re-renders on node position changes. Tests pass.

---
*PR created automatically by Jules for task [15757240500695281797](https://jules.google.com/task/15757240500695281797) started by @njtan142*