### PR TITLE
🎨 Palette: Improve Widget Type selector accessibility

### DIFF
--- a/src/components/Inspector/NodeInspector.tsx
+++ b/src/components/Inspector/NodeInspector.tsx
@@ -236,22 +236,24 @@ const DashboardOutputPanel: React.FC<{ id: string; data: any }> = ({ id, data })
     };
 
     const widgetTypes = [
-        { id: 'chart', icon: <BarChart3 size={14} />, color: 'bg-blue-600 border-blue-500' },
-        { id: 'trend', icon: <TrendingUp size={14} />, color: 'bg-emerald-600 border-emerald-500' },
-        { id: 'text',  icon: <Type size={14} />,       color: 'bg-purple-600 border-purple-500' },
+        { id: 'chart', label: 'Chart Widget', icon: <BarChart3 size={14} />, color: 'bg-blue-600 border-blue-500' },
+        { id: 'trend', label: 'Trend Widget', icon: <TrendingUp size={14} />, color: 'bg-emerald-600 border-emerald-500' },
+        { id: 'text',  label: 'Text Widget', icon: <Type size={14} />,       color: 'bg-purple-600 border-purple-500' },
     ] as const;
 
     return (
         <>
             <Row label="Widget Type">
-                <div className="flex gap-2">
-                    {widgetTypes.map(({ id: wt, icon, color }) => (
+                <div className="flex gap-2" role="group" aria-label="Select widget type">
+                    {widgetTypes.map(({ id: wt, label, icon, color }) => (
                         <Button
                             key={wt}
                             size="icon-xs"
                             variant={data.widgetType === wt ? 'default' : 'outline'}
                             className={data.widgetType === wt ? `${color} text-zinc-900 dark:text-white` : 'text-zinc-400'}
-                            title={wt}
+                            title={label}
+                            aria-label={label}
+                            aria-pressed={data.widgetType === wt}
                             onClick={() => handleWidgetType(wt)}
                         >
                             {icon}


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the "Widget Type" icon-only buttons in the Node Inspector (`NodeInspector.tsx`). Added `role="group"` to the container, and `aria-label`, `aria-pressed`, and `title` to the individual toggle buttons.

🎯 **Why:** Previously, the widget type buttons were icon-only and lacked proper grouping and state indicators. Screen reader users would have difficulty understanding the group's purpose, the buttons' functions, and which button was currently active. 

📸 **Before/After:** The visual appearance remains exactly the same, but the underlying markup is now semantically correct for toggle button groups. Tooltips now appear natively on hover thanks to the `title` attribute.

♿ **Accessibility:** 
- The container now uses `role="group"` and `aria-label="Select widget type"` to give context to the group of controls.
- Each button now has an explicit `aria-label` (e.g., "Chart Widget") instead of relying on the raw ID (`chart`).
- Each button explicitly manages its active state using `aria-pressed={true|false}`, providing immediate feedback to assistive technologies about which widget type is selected.

---
*PR created automatically by Jules for task [15046408173319608310](https://jules.google.com/task/15046408173319608310) started by @njtan142*