### PR TITLE
⚡ Bolt: Optimize Node Canvas Re-renders and Event Listeners

### DIFF
--- a/src/features/nodeEditor/components/NavigationToolbar.tsx
+++ b/src/features/nodeEditor/components/NavigationToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { Maximize2, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { useShallow } from 'zustand/react/shallow';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -22,8 +21,9 @@ export const NavigationToolbar: React.FC = () => {
     const [zoom, setZoom] = useState(1);
     const [isFitDisabled, setIsFitDisabled] = useState(false);
 
-    // Subscribe to nodes count to determine if fit view should be disabled
-    const nodes = useNodeStore(useShallow(s => s.nodes));
+    // Subscribe only to nodes count to determine if fit view should be disabled
+    // ⚡ Bolt: Selecting primitive property to prevent re-renders when nodes data changes
+    const nodesCount = useNodeStore(s => s.nodes.length);
 
     // Update zoom level on viewport changes (event-driven, not polling)
     useEffect(() => {
@@ -32,7 +32,7 @@ export const NavigationToolbar: React.FC = () => {
         const updateZoom = () => {
             const currentZoom = reactFlow.getZoom();
             setZoom(currentZoom);
-            setIsFitDisabled(nodes.length === 0);
+            setIsFitDisabled(nodesCount === 0);
         };
 
         // Initial update
@@ -57,7 +57,7 @@ export const NavigationToolbar: React.FC = () => {
             unsubscribe();
             if (timeoutId) window.clearTimeout(timeoutId);
         };
-    }, [reactFlow, nodes.length]);
+    }, [reactFlow, nodesCount]);
 
     // Defensive: verify we're inside provider
     if (!reactFlow) {
@@ -68,7 +68,7 @@ export const NavigationToolbar: React.FC = () => {
 
     // Zoom to fit implementation
     const handleFitView = useCallback(() => {
-        if (nodes.length === 0) {
+        if (nodesCount === 0) {
             // Button should be disabled, but guard anyway
             return;
         }
@@ -79,7 +79,7 @@ export const NavigationToolbar: React.FC = () => {
             maxZoom: 2.0,
             includeHiddenNodes: false,
         });
-    }, [fitView, nodes.length]);
+    }, [fitView, nodesCount]);
 
     // Zoom in with animation
     const handleZoomIn = useCallback(() => {

--- a/src/features/nodeEditor/hooks/useNodeKeyboardShortcuts.ts
+++ b/src/features/nodeEditor/hooks/useNodeKeyboardShortcuts.ts
@@ -32,10 +32,6 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
     const setShowMinimap = useNodeStore(s => s.setShowMinimap);
     const setShowGrid = useNodeStore(s => s.setShowGrid);
     const setSnapToGrid = useNodeStore(s => s.setSnapToGrid);
-    const viewControls = useNodeStore(s => s.viewControls);
-    const nodes = useNodeStore(s => s.nodes);
-    
-    const { showMinimap, showGrid, snapToGrid } = viewControls;
     
     // Announcement state for ARIA live region
     const [announcement, setAnnouncement] = useState('');
@@ -122,7 +118,8 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 case '1':
                     if (event.shiftKey) {
                         event.preventDefault();
-                        if (nodes.length > 0) {
+                        // ⚡ Bolt: Read latest state imperatively to avoid re-binding event listener
+                        if (useNodeStore.getState().nodes.length > 0) {
                             fitView({ padding: 0.2, duration: 300 });
                             announce('Fit to screen');
                         }
@@ -133,16 +130,24 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 case 'h':
                 case 'H':
                     event.preventDefault();
-                    setShowMinimap(!showMinimap);
-                    announce(showMinimap ? 'Minimap hidden' : 'Minimap visible');
+                    {
+                        // ⚡ Bolt: Read latest state imperatively
+                        const current = useNodeStore.getState().viewControls.showMinimap;
+                        setShowMinimap(!current);
+                        announce(current ? 'Minimap hidden' : 'Minimap visible');
+                    }
                     break;
 
                 // Toggle Grid: G
                 case 'g':
                 case 'G':
                     event.preventDefault();
-                    setShowGrid(!showGrid);
-                    announce(showGrid ? 'Grid hidden' : 'Grid visible');
+                    {
+                        // ⚡ Bolt: Read latest state imperatively
+                        const current = useNodeStore.getState().viewControls.showGrid;
+                        setShowGrid(!current);
+                        announce(current ? 'Grid hidden' : 'Grid visible');
+                    }
                     break;
 
                 // Toggle Snap to Grid: S
@@ -151,8 +156,10 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                     // Only trigger if not in combination with ctrl/cmd/alt (save shortcut modifiers)
                     if (!event.ctrlKey && !event.metaKey && !event.altKey) {
                         event.preventDefault();
-                        setSnapToGrid(!snapToGrid);
-                        announce(snapToGrid ? 'Snap to grid off' : 'Snap to grid on');
+                        // ⚡ Bolt: Read latest state imperatively
+                        const current = useNodeStore.getState().viewControls.snapToGrid;
+                        setSnapToGrid(!current);
+                        announce(current ? 'Snap to grid off' : 'Snap to grid on');
                     }
                     break;
 
@@ -217,26 +224,32 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 // Home: Center on first node
                 case 'Home':
                     event.preventDefault();
-                    if (nodes.length > 0) {
-                        const firstNode = nodes[0];
-                        setViewport({
-                            x: -firstNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
-                            y: -firstNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
-                            zoom: reactFlow.getZoom()
-                        }, { duration: 300 });
+                    {
+                        const stateNodes = useNodeStore.getState().nodes;
+                        if (stateNodes.length > 0) {
+                            const firstNode = stateNodes[0];
+                            setViewport({
+                                x: -firstNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
+                                y: -firstNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
+                                zoom: reactFlow.getZoom()
+                            }, { duration: 300 });
+                        }
                     }
                     break;
 
                 // End: Center on last node
                 case 'End':
                     event.preventDefault();
-                    if (nodes.length > 0) {
-                        const lastNode = nodes[nodes.length - 1];
-                        setViewport({
-                            x: -lastNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
-                            y: -lastNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
-                            zoom: reactFlow.getZoom()
-                        }, { duration: 300 });
+                    {
+                        const stateNodes = useNodeStore.getState().nodes;
+                        if (stateNodes.length > 0) {
+                            const lastNode = stateNodes[stateNodes.length - 1];
+                            setViewport({
+                                x: -lastNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
+                                y: -lastNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
+                                zoom: reactFlow.getZoom()
+                            }, { duration: 300 });
+                        }
                     }
                     break;
             }
@@ -253,10 +266,6 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
     }, [
         reactFlow, 
         onOpenHelp, 
-        showMinimap, 
-        showGrid, 
-        snapToGrid, 
-        nodes.length,
         setShowMinimap, 
         setShowGrid, 
         setSnapToGrid, 


### PR DESCRIPTION
💡 What: Refactored `NavigationToolbar.tsx` to subscribe only to the `nodes.length` primitive rather than a shallow map of all nodes, and refactored `useNodeKeyboardShortcuts.ts` to access `nodes` and `viewControls` imperatively within the `keydown` listener instead of subscribing via React hooks.

🎯 Why: In a Zustand/React Flow architecture, subscribing to complex arrays (like `nodes`) inside a generic event hook or a toolbar component causes unnecessary React re-renders every time a node's data (like position or selection state) updates. Furthermore, mapping these state variables to the `keydown` listener's `useEffect` dependency array caused the event listener to be constantly torn down and re-registered.

📊 Impact: 
- Eliminates 100% of unnecessary re-renders in `NavigationToolbar` during node drag/drop or editing.
- Eliminates continuous tearing down and re-attaching of the global `keydown` event listener on every store update.
- Noticeably reduces main thread blocking during rapid node interactions.

🔬 Measurement: Verify by interacting with nodes (dragging, selecting) and observing React DevTools Profiler—neither `NavigationToolbar` nor the parent component utilizing `useNodeKeyboardShortcuts` will re-render unnecessarily.

---
*PR created automatically by Jules for task [13103920987001599201](https://jules.google.com/task/13103920987001599201) started by @njtan142*