### PR TITLE
⚡ Bolt: Optimize previousNodes lookup in edgeDataFlow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+## 2024-05-27 - Optimized node lookup in edgeDataFlow setupNodeDataChangeSubscription
+**Learning:** In the `setupNodeDataChangeSubscription` loop inside `edgeDataFlow`, repeatedly searching for a node by ID in the `previousNodes` array using `Array.prototype.find` resulted in O(N^2) complexity, causing significant main thread blocking and jank when dealing with large graphs.
+**Action:** Always index local state items (e.g., `previousNodes`) into a `Map` by identifier before the loop. This reduces lookup complexity from $O(N)$ to $O(1)$, converting the overall operation from $O(N^2)$ to $O(N)$.

--- a/src/features/nodeEditor/utils/edgeDataFlow.ts
+++ b/src/features/nodeEditor/utils/edgeDataFlow.ts
@@ -163,9 +163,16 @@ export function setupNodeDataChangeSubscription(): () => void {
     const unsubscribe = useNodeStore.subscribe(
         (state) => state.nodes, // Select only nodes array
         (currentNodes, previousNodes) => {
+            // ⚡ Bolt: Index previousNodes into a Map by id before the loop.
+            // This reduces lookup complexity from O(N^2) to O(N) when detecting changes in large graphs.
+            const previousNodesMap = new Map();
+            for (let i = 0; i < previousNodes.length; i++) {
+                previousNodesMap.set(previousNodes[i].id, previousNodes[i]);
+            }
+
             // Find nodes whose data has changed
             const changedNodes = currentNodes.filter(currentNode => {
-                const previousNode = previousNodes.find(p => p.id === currentNode.id);
+                const previousNode = previousNodesMap.get(currentNode.id);
                 if (!previousNode) return false; // New node, not a change
 
                 // Compare data objects (shallow comparison)

--- a/src/features/nodeEditor/utils/edgeDataFlow.ts
+++ b/src/features/nodeEditor/utils/edgeDataFlow.ts
@@ -1,5 +1,4 @@
 import { useNodeStore } from '../../../stores/useNodeStore';
-import { CanvasNode, CanvasEdge } from '../../../types/nodeEditor';
 
 /**
  * Get the current output data from a source node

--- a/src/tests/features/nodeEditor/utils/edgeDataFlow.test.ts
+++ b/src/tests/features/nodeEditor/utils/edgeDataFlow.test.ts
@@ -457,7 +457,7 @@ describe('edgeDataFlow', () => {
 
         it('should propagate changes when node data changes', () => {
             const mockUnsubscribe = vi.fn();
-            (useNodeStore.subscribe as any).mockImplementation((selector, listener) => {
+            (useNodeStore.subscribe as any).mockImplementation((_selector: any, listener: any) => {
                 // Simulate calling the listener with changed nodes
                 const currentNodes = [
                     { id: 'node1', type: 'ledgerSource', data: { entries: [1, 2, 3] } }


### PR DESCRIPTION
💡 What: Optimized `setupNodeDataChangeSubscription` in `edgeDataFlow.ts` by indexing `previousNodes` into a `Map` before running the `filter` loop.
🎯 Why: Previously, finding the corresponding previous node used `Array.prototype.find()` inside the `filter` loop over `currentNodes`. This created an $O(N^2)$ time complexity, which causes performance issues when the node graph becomes large (e.g. 10,000 nodes).
📊 Impact: Reduces the time complexity of the data change detection loop from $O(N^2)$ to $O(N)$. This significantly improves main thread performance during node graph updates.
🔬 Measurement: Verified that tests pass via `pnpm test src/tests/features/nodeEditor/utils/edgeDataFlow.test.ts`. For large graphs, performance profiles should show reduced blocking time in the Zustand state subscriber.

---
*PR created automatically by Jules for task [6413582652473095536](https://jules.google.com/task/6413582652473095536) started by @njtan142*