### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to project and workflow cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Playwright Verification Context & Dashboard Icons
 **Learning:** The Dashboard page contains heavily icon-centric action bars (e.g. Inspector open/close, view toggles) which completely lack screen reader accessibility. Verifying these required automating the TOTP and Profile setup flows, revealing that Playwright struggles to click nested elements inside the Profile Card unless targeting specific text nodes.
 **Action:** When adding `aria-labels` to complex dashboards, always ensure `aria-pressed` states are added for toggles. When verifying via Playwright, bypass profile card container clicks by specifically locating and clicking the nested `h3` profile name element.
+
+## 2024-05-18 - Keyboard Accessibility for Interactive Divs/Cards
+**Learning:** When using custom components like `<Card>` or standard `<div>` elements as clickable cards (e.g., project or workflow selectors), they inherently lack keyboard accessibility. Even if they have an `onClick` handler and hover states, screen reader and keyboard-only users cannot interact with them.
+**Action:** Always add `role="button"`, `tabIndex={0}`, an appropriate `aria-label`, an `onKeyDown` handler listening for 'Enter' and ' ' (space) to trigger the click action, and `focus-visible` styles to ensure these interactive elements are fully accessible.

--- a/src/features/nodeEditor/WorkflowScriptList.tsx
+++ b/src/features/nodeEditor/WorkflowScriptList.tsx
@@ -262,8 +262,17 @@ export const WorkflowScriptList: React.FC = () => {
                         {workflows.map((workflow) => (
                             <Card
                                 key={workflow._id}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`Open workflow ${workflow.name}`}
                                 onClick={() => handleCardClick(workflow._id)}
-                                className="group relative flex flex-col p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl hover:border-emerald-500/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-all cursor-pointer shadow-sm hover:shadow-emerald-900/10"
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        handleCardClick(workflow._id);
+                                    }
+                                }}
+                                className="group relative flex flex-col p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl hover:border-emerald-500/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-all cursor-pointer shadow-sm hover:shadow-emerald-900/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-950"
                             >
                                 <div className="flex items-start justify-between mb-4">
                                     <div className="p-2.5 bg-zinc-100 dark:bg-zinc-800 rounded-lg text-emerald-600 dark:text-emerald-400 group-hover:scale-110 transition-transform">

--- a/src/features/projects/ProjectDashboard.tsx
+++ b/src/features/projects/ProjectDashboard.tsx
@@ -101,8 +101,17 @@ export const ProjectDashboard: React.FC = () => {
                         {projects.map((project) => (
                             <Card
                                 key={project._id}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`Open project ${project.name}`}
                                 onClick={() => handleProjectClick(project._id)}
-                                className="group relative flex flex-col p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl hover:border-emerald-500/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-all cursor-pointer shadow-sm hover:shadow-emerald-900/10"
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        handleProjectClick(project._id);
+                                    }
+                                }}
+                                className="group relative flex flex-col p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl hover:border-emerald-500/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-all cursor-pointer shadow-sm hover:shadow-emerald-900/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-950"
                             >
                                 <div className="flex items-start justify-between mb-4">
                                     <div className="p-2.5 bg-zinc-100 dark:bg-zinc-800 rounded-lg text-emerald-600 dark:text-emerald-400 group-hover:scale-110 transition-transform">


### PR DESCRIPTION
💡 **What**: Added comprehensive keyboard accessibility to the clickable `<Card>` elements in `ProjectDashboard` and `WorkflowScriptList` (projects and workflow lists).
🎯 **Why**: These cards function as buttons (triggering navigation on click) but used standard `div` semantics natively. As a result, keyboard-only users and screen readers couldn't focus, understand, or interact with them, breaking navigation.
📸 **Before/After**: 
- Before: Cards could only be clicked with a mouse. Tabbing skipped them entirely.
- After: Cards can be focused via `Tab`, display a clear emerald focus ring, announce their purpose (e.g., "Open project My Project"), and can be activated using `Enter` or `Space`.
♿ **Accessibility**: 
- Added `role="button"` and `tabIndex={0}` for focusability and semantics.
- Added `aria-label` to provide context for screen readers.
- Added `onKeyDown` to handle 'Enter' and 'Space' activation.
- Added `focus-visible:ring-2 focus-visible:ring-emerald-500` for clear visual focus indicators.

---
*PR created automatically by Jules for task [16196814693226898553](https://jules.google.com/task/16196814693226898553) started by @njtan142*