### PR TITLE
🎨 Palette: Add aria-pressed to dashboard toggle buttons

### DIFF
--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -398,6 +398,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleLeftSidebar}
                                             aria-label={leftSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+                                            aria-pressed={leftSidebarOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {leftSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
@@ -423,6 +424,7 @@ export const AppShell: React.FC = () => {
                                                 size="icon"
                                                 onClick={() => setDashboardViewMode(prev => prev === 'grid' ? 'table' : 'grid')}
                                                 aria-label={dashboardViewMode === 'grid' ? 'Switch to Table View' : 'Switch to Grid View'}
+                                                aria-pressed={dashboardViewMode === 'grid'}
                                                 className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                             >
                                                 {dashboardViewMode === 'grid' ? <Table size={18} /> : <Grid3X3 size={18} />}
@@ -440,6 +442,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleTheme}
                                             aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+                                            aria-pressed={theme === 'dark'}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -457,6 +460,7 @@ export const AppShell: React.FC = () => {
                                             size="icon"
                                             onClick={toggleRightInspector}
                                             aria-label={rightInspectorOpen ? 'Close inspector' : 'Open inspector'}
+                                            aria-pressed={rightInspectorOpen}
                                             className="border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                         >
                                             <PanelRightClose size={18} className={rightInspectorOpen ? '' : 'rotate-180'} />


### PR DESCRIPTION
💡 What: Added `aria-pressed` state attributes to the four icon-only toggle buttons in the main application shell toolbar (Left Sidebar, Dashboard View Mode, Theme, Right Inspector).

🎯 Why: Icon-only toggle buttons often rely purely on visual cues (like an icon change or active background) to indicate their state. This prevents screen reader users from knowing whether a toggle (e.g. the sidebar) is currently open or closed. Adding `aria-pressed` conveys this crucial state information directly to assistive technologies.

📸 Before/After: Visuals remain unchanged, but the DOM now reflects the accurate boolean state via `aria-pressed` for screen reader accessibility.

♿ Accessibility: Ensures that state-switching icon buttons are fully accessible and their active/inactive status is properly announced.

---
*PR created automatically by Jules for task [4404025887909659429](https://jules.google.com/task/4404025887909659429) started by @njtan142*