### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak RNG in Node IDs

### DIFF
--- a/src/features/nodeEditor/NodeCanvas.tsx
+++ b/src/features/nodeEditor/NodeCanvas.tsx
@@ -575,7 +575,14 @@ const generateNodeId = (): string => {
     }
     // Fallback: generate UUID v4 manually
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-        const r = Math.random() * 16 | 0;
+        let r;
+        if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+            const arr = new Uint8Array(1);
+            crypto.getRandomValues(arr);
+            r = arr[0] & 15;
+        } else {
+            r = Math.random() * 16 | 0;
+        }
         const v = c === 'x' ? r : (r & 0x3 | 0x8);
         return v.toString(16);
     });


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Weak Random Number Generation. The fallback mechanism for generating UUIDs in the NodeCanvas used `Math.random()`, which is a predictable pseudorandom number generator (PRNG) and not cryptographically secure.
🎯 **Impact:** If `crypto.randomUUID` is unavailable in the environment, predictable node IDs could potentially lead to ID collisions or allow an attacker to predict generated IDs in certain deployment contexts.
🔧 **Fix:** Updated the `generateNodeId` fallback to prefer the Cryptographically Secure PRNG `crypto.getRandomValues()` when Web Crypto API is available, using a bitwise AND operation (`val & 15`) to safely extract uniform random values from 0-15.
✅ **Verification:** Ran `pnpm exec tsc --noEmit` and passed code review. Validated the bitwise math manually to ensure uniform distribution without bias (e.g. avoided `val / 255 * 16 | 0`).

---
*PR created automatically by Jules for task [5688873781411116831](https://jules.google.com/task/5688873781411116831) started by @njtan142*