### PR TITLE
⚡ Bolt: Replace continuous viewport transform subscriptions with useOnViewportChange

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-05-18 - Avoid useStore(s => s.transform) in XYFlow
+**Learning:** Subscribing directly to the viewport transform via `useStore(s => s.transform)` in ReactFlow/XYFlow is an anti-pattern that causes continuous component re-renders (60fps) during pan or zoom interactions.
+**Action:** Use the `useOnViewportChange` hook instead to react to viewport changes efficiently, especially when throttling/debouncing spatial index rebuilds or other expensive recalculations that depend on the viewport.

--- a/src/features/nodeEditor/hooks/useHandlePositions.ts
+++ b/src/features/nodeEditor/hooks/useHandlePositions.ts
@@ -10,10 +10,10 @@
  */
 
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
-import { useReactFlow, useStore, type XYPosition } from '@xyflow/react';
+import { useReactFlow, useOnViewportChange, type XYPosition } from '@xyflow/react';
 import type { Node } from '@xyflow/react';
 import type { HandlePosition, PortType } from '../types/connection';
-import { HandleSpatialIndex, createSpatialIndex, DEFAULT_VIEWPORT_PADDING } from '../utils/snapDetection';
+import { HandleSpatialIndex, createSpatialIndex } from '../utils/snapDetection';
 import { getPortTypeFromHandle } from '../utils/portTypeUtils';
 
 /**
@@ -115,7 +115,6 @@ export const useHandlePositions = (
 ): UseHandlePositionsReturn => {
     const { enabled = true } = options;
     const { getNodes, screenToFlowPosition } = useReactFlow();
-    const viewport = useStore(s => s.transform);
 
     // State to trigger rebuilds
     const [rebuildTrigger, setRebuildTrigger] = useState(0);
@@ -124,6 +123,7 @@ export const useHandlePositions = (
     const lastRebuildRef = useRef<number>(0);
     const spatialIndexRef = useRef<HandleSpatialIndex | null>(null);
     const handlePositionsRef = useRef<HandlePosition[]>([]);
+    const viewportTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
     // Memoized handle positions
     const handlePositions = useMemo(() => {
@@ -133,7 +133,7 @@ export const useHandlePositions = (
         const positions = extractHandlePositions(nodes, screenToFlowPosition);
         handlePositionsRef.current = positions;
         return positions;
-    }, [getNodes, enabled, rebuildTrigger, viewport, screenToFlowPosition]);
+    }, [getNodes, enabled, rebuildTrigger, screenToFlowPosition]);
 
     // Build spatial index
     const spatialIndex = useMemo(() => {
@@ -159,20 +159,27 @@ export const useHandlePositions = (
     }, []);
 
     // Rebuild index when viewport changes (debounced)
-    useEffect(() => {
-        if (!enabled) return;
+    useOnViewportChange({
+        onChange: useCallback(() => {
+            if (!enabled) return;
 
-        const timer = setTimeout(() => {
-            rebuildIndex();
-        }, VIEWPORT_DEBOUNCE_MS);
+            if (viewportTimeoutRef.current) {
+                clearTimeout(viewportTimeoutRef.current);
+            }
 
-        return () => clearTimeout(timer);
-    }, [viewport, enabled, rebuildIndex]);
+            viewportTimeoutRef.current = setTimeout(() => {
+                rebuildIndex();
+            }, VIEWPORT_DEBOUNCE_MS);
+        }, [enabled, rebuildIndex])
+    });
 
     // Cleanup on unmount
     useEffect(() => {
         return () => {
             spatialIndexRef.current = null;
+            if (viewportTimeoutRef.current) {
+                clearTimeout(viewportTimeoutRef.current);
+            }
         };
     }, []);
 
@@ -191,7 +198,6 @@ export const useViewportHandlePositions = (
     canvasSize: { width: number; height: number }
 ) => {
     const { spatialIndex, handlePositions } = useHandlePositions();
-    const viewport = useStore(s => s.transform);
 
     const visibleHandles = useMemo(() => {
         if (!spatialIndex) return [];
@@ -210,7 +216,7 @@ export const useViewportHandlePositions = (
             { x: viewCenterX, y: viewCenterY },
             queryRadius
         );
-    }, [spatialIndex, viewport, canvasSize]);
+    }, [spatialIndex, canvasSize]);
 
     return {
         spatialIndex,


### PR DESCRIPTION
💡 **What:** Replaced the `useStore(s => s.transform)` subscription with `useOnViewportChange` in `src/features/nodeEditor/hooks/useHandlePositions.ts`.
🎯 **Why:** Subscribing directly to the viewport transform causes continuous component re-renders (at 60fps) during any pan or zoom interactions, severely degrading performance on large canvases.
📊 **Impact:** Prevents continuous 60fps re-renders of components utilizing the handle positioning hooks during pan and zoom interactions, improving layout performance and decreasing CPU usage.
🔬 **Measurement:** Verify by recording a React Profiler trace while panning the canvas. The components utilizing `useHandlePositions` or `useViewportHandlePositions` will no longer re-render continuously.

---
*PR created automatically by Jules for task [13796017397838122934](https://jules.google.com/task/13796017397838122934) started by @njtan142*