### PR TITLE
🎨 Palette: Improve accessibility of Node Toolbar buttons

### DIFF
--- a/src/features/nodeEditor/NodeToolbar.tsx
+++ b/src/features/nodeEditor/NodeToolbar.tsx
@@ -145,6 +145,7 @@ export const NodeToolbar: React.FC<NodeToolbarProps> = () => {
                     onClick={handleManualSave}
                     disabled={isSaveInProgress || !isCanvasLoaded}
                     title="Save workflow (Ctrl+S)"
+                    aria-label="Save workflow (Ctrl+S)"
                 >
                     <span className={saveError ? 'text-red-400' : 'text-zinc-400'}>
                         {saveStatusIcon ?? <Save size={16} />}
@@ -174,6 +175,7 @@ const ToolbarButton: React.FC<ToolbarButtonProps> = ({ icon, label, onClick, col
         className="justify-start gap-3 hover:bg-gray-200 dark:hover:bg-zinc-800 h-9 px-3"
         onClick={onClick}
         title={label}
+        aria-label={label}
     >
         <span className={color}>{icon}</span>
         <span className="text-xs font-medium text-zinc-300">{label}</span>


### PR DESCRIPTION
💡 What: Added `aria-label` to the manual save button and the `ToolbarButton` component in the `NodeToolbar`.
🎯 Why: To ensure icon-only buttons (like the Save button when it only shows an icon) and custom toolbar buttons are properly announced by screen readers, improving accessibility.
📸 Before/After: Visuals remain unchanged. Screen readers will now announce "Save workflow (Ctrl+S)" or the respective label of the `ToolbarButton`.
♿ Accessibility: Improves screen reader support for interactive toolbar elements.

---
*PR created automatically by Jules for task [12774119582194083751](https://jules.google.com/task/12774119582194083751) started by @njtan142*