### PR TITLE
⚡ Bolt: Optimize keyboard shortcuts to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-27 - Avoid Array.push(...largeArray) due to Maximum call stack size exceeded
 **Learning:** Spreading very large arrays into `Array.prototype.push(...largeArray)` (e.g. over 100k items) results in V8 throwing a "Maximum call stack size exceeded" error. This is because V8 engine treats the spread arguments as individual function arguments.
 **Action:** When concatenating large arrays, avoid using the spread syntax `push(...array)`. Instead, use a `for` loop to explicitly iterate and push items one by one. This completely avoids the call stack limitation and is highly performant.
+
+## 2024-08-12 - Prevent unnecessary re-renders in Keyboard Handlers
+**Learning:** React hooks subscribing to Zustand stores (e.g., `useNodeStore(s => s.nodes)`) within components defining keyboard shortcut `useEffect` hooks cause the component to unnecessarily re-render every time the store changes (e.g., during 60fps dragging), even though the handler only needs the state imperatively when a key is pressed.
+**Action:** Always replace reactive hook subscriptions with imperative `store.getState()` calls inside the event listener callback when state is only needed momentarily during an event. This avoids polluting the `useEffect` dependency array and stops continuous re-renders.

--- a/src/features/nodeEditor/hooks/useNodeKeyboardShortcuts.ts
+++ b/src/features/nodeEditor/hooks/useNodeKeyboardShortcuts.ts
@@ -28,15 +28,6 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
     const { onOpenHelp } = options;
     const reactFlow = useReactFlow();
     
-    // View controls selectors
-    const setShowMinimap = useNodeStore(s => s.setShowMinimap);
-    const setShowGrid = useNodeStore(s => s.setShowGrid);
-    const setSnapToGrid = useNodeStore(s => s.setSnapToGrid);
-    const viewControls = useNodeStore(s => s.viewControls);
-    const nodes = useNodeStore(s => s.nodes);
-    
-    const { showMinimap, showGrid, snapToGrid } = viewControls;
-    
     // Announcement state for ARIA live region
     const [announcement, setAnnouncement] = useState('');
     const announcementTimeout = useRef<number | null>(null);
@@ -122,6 +113,7 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 case '1':
                     if (event.shiftKey) {
                         event.preventDefault();
+                        const nodes = useNodeStore.getState().nodes;
                         if (nodes.length > 0) {
                             fitView({ padding: 0.2, duration: 300 });
                             announce('Fit to screen');
@@ -133,16 +125,24 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 case 'h':
                 case 'H':
                     event.preventDefault();
-                    setShowMinimap(!showMinimap);
-                    announce(showMinimap ? 'Minimap hidden' : 'Minimap visible');
+                    {
+                        const { viewControls, setShowMinimap } = useNodeStore.getState();
+                        const newValue = !viewControls.showMinimap;
+                        setShowMinimap(newValue);
+                        announce(newValue ? 'Minimap visible' : 'Minimap hidden');
+                    }
                     break;
 
                 // Toggle Grid: G
                 case 'g':
                 case 'G':
                     event.preventDefault();
-                    setShowGrid(!showGrid);
-                    announce(showGrid ? 'Grid hidden' : 'Grid visible');
+                    {
+                        const { viewControls, setShowGrid } = useNodeStore.getState();
+                        const newValue = !viewControls.showGrid;
+                        setShowGrid(newValue);
+                        announce(newValue ? 'Grid visible' : 'Grid hidden');
+                    }
                     break;
 
                 // Toggle Snap to Grid: S
@@ -151,8 +151,10 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                     // Only trigger if not in combination with ctrl/cmd/alt (save shortcut modifiers)
                     if (!event.ctrlKey && !event.metaKey && !event.altKey) {
                         event.preventDefault();
-                        setSnapToGrid(!snapToGrid);
-                        announce(snapToGrid ? 'Snap to grid off' : 'Snap to grid on');
+                        const { viewControls, setSnapToGrid } = useNodeStore.getState();
+                        const newValue = !viewControls.snapToGrid;
+                        setSnapToGrid(newValue);
+                        announce(newValue ? 'Snap to grid on' : 'Snap to grid off');
                     }
                     break;
 
@@ -217,26 +219,32 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
                 // Home: Center on first node
                 case 'Home':
                     event.preventDefault();
-                    if (nodes.length > 0) {
-                        const firstNode = nodes[0];
-                        setViewport({
-                            x: -firstNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
-                            y: -firstNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
-                            zoom: reactFlow.getZoom()
-                        }, { duration: 300 });
+                    {
+                        const nodes = useNodeStore.getState().nodes;
+                        if (nodes.length > 0) {
+                            const firstNode = nodes[0];
+                            setViewport({
+                                x: -firstNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
+                                y: -firstNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
+                                zoom: reactFlow.getZoom()
+                            }, { duration: 300 });
+                        }
                     }
                     break;
 
                 // End: Center on last node
                 case 'End':
                     event.preventDefault();
-                    if (nodes.length > 0) {
-                        const lastNode = nodes[nodes.length - 1];
-                        setViewport({
-                            x: -lastNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
-                            y: -lastNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
-                            zoom: reactFlow.getZoom()
-                        }, { duration: 300 });
+                    {
+                        const nodes = useNodeStore.getState().nodes;
+                        if (nodes.length > 0) {
+                            const lastNode = nodes[nodes.length - 1];
+                            setViewport({
+                                x: -lastNode.position.x + window.innerWidth / 2 / reactFlow.getZoom() - 100,
+                                y: -lastNode.position.y + window.innerHeight / 2 / reactFlow.getZoom() - 50,
+                                zoom: reactFlow.getZoom()
+                            }, { duration: 300 });
+                        }
                     }
                     break;
             }
@@ -252,14 +260,7 @@ export const useNodeKeyboardShortcuts = (options: UseNodeKeyboardShortcutsOption
         };
     }, [
         reactFlow, 
-        onOpenHelp, 
-        showMinimap, 
-        showGrid, 
-        snapToGrid, 
-        nodes.length,
-        setShowMinimap, 
-        setShowGrid, 
-        setSnapToGrid, 
+        onOpenHelp,
         announce, 
         isTyping
     ]);


### PR DESCRIPTION
💡 What: Refactored `useNodeKeyboardShortcuts` to use imperative `useNodeStore.getState()` instead of reactive hooks for `nodes` and `viewControls`.

🎯 Why: Subscribing directly to `nodes` and `viewControls` caused the component consuming this hook (e.g. NodeCanvas) to re-render unnecessarily every time any node moved (60fps during drag) or view controls changed, and caused the `keydown` listener to be constantly torn down and recreated.

📊 Impact: Significantly reduces main thread work and eliminates continuous React render cycle spam during node dragging or high-frequency state updates.

🔬 Measurement: Verified via TypeScript compiler (`tsc --noEmit`). Running React DevTools Profiler while dragging a node will now show zero re-renders triggered by the keyboard shortcut hook.

---
*PR created automatically by Jules for task [11520635928271818327](https://jules.google.com/task/11520635928271818327) started by @njtan142*