### PR TITLE
⚡ Bolt: Debounce viewport updates to eliminate 60fps re-renders

### DIFF
--- a/src/features/nodeEditor/hooks/useHandlePositions.ts
+++ b/src/features/nodeEditor/hooks/useHandlePositions.ts
@@ -10,17 +10,16 @@
  */
 
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
-import { useReactFlow, useStore, type XYPosition } from '@xyflow/react';
+import { useReactFlow, useOnViewportChange, type XYPosition } from '@xyflow/react';
 import type { Node } from '@xyflow/react';
 import type { HandlePosition, PortType } from '../types/connection';
-import { HandleSpatialIndex, createSpatialIndex, DEFAULT_VIEWPORT_PADDING } from '../utils/snapDetection';
+import { HandleSpatialIndex, createSpatialIndex } from '../utils/snapDetection';
 import { getPortTypeFromHandle } from '../utils/portTypeUtils';
 
 /**
  * Performance configuration
  */
 const REBUILD_THROTTLE_MS = 100; // ms - throttle handle position rebuilds
-const VIEWPORT_DEBOUNCE_MS = 100; // ms - debounce viewport change handling
 const DEFAULT_NODE_WIDTH = 200; // px - default width for bounds calculation
 const DEFAULT_NODE_HEIGHT = 100; // px - default height for bounds calculation
 
@@ -115,7 +114,6 @@ export const useHandlePositions = (
 ): UseHandlePositionsReturn => {
     const { enabled = true } = options;
     const { getNodes, screenToFlowPosition } = useReactFlow();
-    const viewport = useStore(s => s.transform);
 
     // State to trigger rebuilds
     const [rebuildTrigger, setRebuildTrigger] = useState(0);
@@ -133,7 +131,7 @@ export const useHandlePositions = (
         const positions = extractHandlePositions(nodes, screenToFlowPosition);
         handlePositionsRef.current = positions;
         return positions;
-    }, [getNodes, enabled, rebuildTrigger, viewport, screenToFlowPosition]);
+    }, [getNodes, enabled, rebuildTrigger, screenToFlowPosition]);
 
     // Build spatial index
     const spatialIndex = useMemo(() => {
@@ -158,16 +156,14 @@ export const useHandlePositions = (
         setRebuildTrigger(prev => prev + 1);
     }, []);
 
-    // Rebuild index when viewport changes (debounced)
-    useEffect(() => {
-        if (!enabled) return;
-
-        const timer = setTimeout(() => {
-            rebuildIndex();
-        }, VIEWPORT_DEBOUNCE_MS);
-
-        return () => clearTimeout(timer);
-    }, [viewport, enabled, rebuildIndex]);
+    // Rebuild index when viewport panning/zooming ends
+    useOnViewportChange({
+        onEnd: () => {
+            if (enabled) {
+                rebuildIndex();
+            }
+        }
+    });
 
     // Cleanup on unmount
     useEffect(() => {
@@ -191,13 +187,19 @@ export const useViewportHandlePositions = (
     canvasSize: { width: number; height: number }
 ) => {
     const { spatialIndex, handlePositions } = useHandlePositions();
-    const viewport = useStore(s => s.transform);
+    const [visibleHandles, setVisibleHandles] = useState<HandlePosition[]>([]);
 
-    const visibleHandles = useMemo(() => {
-        if (!spatialIndex) return [];
+    const updateVisibleHandles = useCallback(() => {
+        if (!spatialIndex) {
+            setVisibleHandles([]);
+            return;
+        }
         
         // Guard against zero canvas dimensions
-        if (canvasSize.width <= 0 || canvasSize.height <= 0) return [];
+        if (canvasSize.width <= 0 || canvasSize.height <= 0) {
+            setVisibleHandles([]);
+            return;
+        }
 
         // Calculate viewport bounds in screen coordinates
         const viewCenterX = canvasSize.width / 2;
@@ -206,11 +208,23 @@ export const useViewportHandlePositions = (
         // Query a larger area around viewport for smooth edge dragging
         const queryRadius = Math.max(canvasSize.width, canvasSize.height) / 2 + 100;
         
-        return spatialIndex.queryRange(
-            { x: viewCenterX, y: viewCenterY },
-            queryRadius
+        setVisibleHandles(
+            spatialIndex.queryRange(
+                { x: viewCenterX, y: viewCenterY },
+                queryRadius
+            )
         );
-    }, [spatialIndex, viewport, canvasSize]);
+    }, [spatialIndex, canvasSize]);
+
+    // Initial trigger when index or canvas size changes
+    useEffect(() => {
+        updateVisibleHandles();
+    }, [updateVisibleHandles]);
+
+    // Trigger when viewport panning/zooming ends
+    useOnViewportChange({
+        onEnd: updateVisibleHandles
+    });
 
     return {
         spatialIndex,


### PR DESCRIPTION
💡 What: Replaced the direct `useStore(s => s.transform)` state subscription with `useOnViewportChange({ onEnd: ... })` in `src/features/nodeEditor/hooks/useHandlePositions.ts`. Migrated dependent `useMemo` hooks to `useState` for proper lifecycle management.
🎯 Why: React Flow's `useStore(s => s.transform)` triggers component re-renders on every animation frame (60fps) during panning or zooming. This caused severe lag, particularly for the spatial indexing of handles.
📊 Impact: Completely eliminates continuous re-renders during viewport interactions. Handle positions and the spatial quadtree are now rebuilt only once when the user finishes panning or zooming, vastly improving editor responsiveness on large graphs.
🔬 Measurement: Verify by panning around a canvas with multiple connected nodes. Use React DevTools Profiler to confirm that `useHandlePositions` and its host components do not re-render until the panning stops.

---
*PR created automatically by Jules for task [12543124501561917363](https://jules.google.com/task/12543124501561917363) started by @njtan142*